### PR TITLE
fix(ui): 修复 Markdown 弹窗中超链接点击无反应

### DIFF
--- a/Plain Craft Launcher 2/Controls/MyMsg/MyMsgMarkdown.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyMsg/MyMsgMarkdown.xaml.cs
@@ -51,8 +51,15 @@ public partial class MyMsgMarkdown
     private static void _OpenHyperlink(object sender, ExecutedRoutedEventArgs e)
     {
         var url = e.Parameter?.ToString();
-        if (!string.IsNullOrWhiteSpace(url))
-            ModBase.OpenWebsite(url);
+        if (string.IsNullOrWhiteSpace(url))
+            return;
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            ModBase.Log("[Control] 已忽略非 http(s) 的 Markdown 链接：" + url, ModBase.LogLevel.Developer);
+            return;
+        }
+        ModBase.OpenWebsite(url);
     }
 
     private void ConfigurePrimaryButton(string text, bool isWarn)

--- a/Plain Craft Launcher 2/Controls/MyMsg/MyMsgMarkdown.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyMsg/MyMsgMarkdown.xaml.cs
@@ -17,6 +17,7 @@ public partial class MyMsgMarkdown
         try
         {
             InitializeComponent();
+            CommandBindings.Add(new CommandBinding(Markdig.Wpf.Commands.Hyperlink, _OpenHyperlink));
             AppendUniqueNameSuffix(Btn1);
             AppendUniqueNameSuffix(Btn2);
             AppendUniqueNameSuffix(Btn3);
@@ -45,6 +46,13 @@ public partial class MyMsgMarkdown
     private void AppendUniqueNameSuffix(FrameworkElement element)
     {
         element.Name += ModBase.GetUuid();
+    }
+
+    private static void _OpenHyperlink(object sender, ExecutedRoutedEventArgs e)
+    {
+        var url = e.Parameter?.ToString();
+        if (!string.IsNullOrWhiteSpace(url))
+            ModBase.OpenWebsite(url);
     }
 
     private void ConfigurePrimaryButton(string text, bool isWarn)


### PR DESCRIPTION
Markdig.Wpf 的超链接点击会发出 Markdig.Wpf.Commands.Hyperlink 路由命令，需由宿主绑定处理才会导航；MyMsgMarkdown 从未绑定该命令，导致更新日志等Markdown 弹窗中的蓝色链接渲染正常但点击无任何反应。

在 MyMsgMarkdown 构造中为该命令添加 CommandBinding，处理器取命令参数（URL）交由 ModBase.OpenWebsite 打开。一处修复覆盖所有 Markdown 弹窗（更新日志、反馈详情、设置-更新的更新日志详情）。

resolves #3419 

本PR的提交信息生成由Claude Code Opus 4.8生成，由Opus 4.8对代码进行了审查。

## Summary by Sourcery

Bug Fixes:
- 修复在更新日志和其他 Markdown 弹窗中，Markdown 对话框中的超链接虽然显示为蓝色链接但点击无响应的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix Markdown dialog hyperlinks that rendered as blue links but did not respond to clicks in update logs and other Markdown popups.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 修复在更新日志和其他 Markdown 弹窗中，Markdown 对话框中的超链接虽然显示为蓝色链接但点击无响应的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix Markdown dialog hyperlinks that rendered as blue links but did not respond to clicks in update logs and other Markdown popups.

</details>

</details>