### PR TITLE
refactor(downloader): 重构下载器分片与系统资源分配逻辑

### DIFF
--- a/PCL.Core/App/Config.cs
+++ b/PCL.Core/App/Config.cs
@@ -76,6 +76,7 @@ public static partial class Config
         [ConfigItem<int>("ToolDownloadThread", 63)] public partial int ThreadLimit { get; set; }
         [ConfigItem<int>("ToolDownloadFileConnection", 7)] public partial int FileConnectionLimit { get; set; }
         [ConfigItem<int>("ToolDownloadSpeed", 42)] public partial int SpeedLimit { get; set; }
+        [ConfigItem<DownloadHttpMode>("ToolDownloadHttpMode", DownloadHttpMode.Auto)] public partial DownloadHttpMode HttpMode { get; set; }
         [ConfigItem<int>("ToolDownloadSource", 1)] public partial int FileSource { get; set; }
         [ConfigItem<int>("ToolDownloadVersion", 1)] public partial int VersionListSource { get; set; }
         [ConfigItem<bool>("ToolDownloadAutoSelectVersion", true)] public partial bool AutoSelectInstance { get; set; }

--- a/PCL.Core/App/Config.cs
+++ b/PCL.Core/App/Config.cs
@@ -72,7 +72,9 @@ public static partial class Config
     /// </summary>
     [ConfigGroup("Download")] partial class DownloadConfigGroup
     {
+        // 保留原配置键，升级后仍沿用用户已设置的数值（值 + 1 为连接上限）。
         [ConfigItem<int>("ToolDownloadThread", 63)] public partial int ThreadLimit { get; set; }
+        [ConfigItem<int>("ToolDownloadFileConnection", 7)] public partial int FileConnectionLimit { get; set; }
         [ConfigItem<int>("ToolDownloadSpeed", 42)] public partial int SpeedLimit { get; set; }
         [ConfigItem<int>("ToolDownloadSource", 1)] public partial int FileSource { get; set; }
         [ConfigItem<int>("ToolDownloadVersion", 1)] public partial int VersionListSource { get; set; }

--- a/PCL.Core/App/ConfigEnums.cs
+++ b/PCL.Core/App/ConfigEnums.cs
@@ -10,6 +10,16 @@ public enum LinkProtocolPreference
 }
 
 /// <summary>
+/// 文件下载使用的 HTTP 协议模式。
+/// </summary>
+public enum DownloadHttpMode
+{
+    Auto = 0,
+    Http11 = 1,
+    Http2 = 2
+}
+
+/// <summary>
 /// 主题模式（亮/暗/系统）
 /// </summary>
 public enum ColorMode

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -2678,6 +2678,13 @@
     <sys:String x:Key="Setup.GameManage.Download.Threads.ToolTip">Limits the total network connections used by all download tasks. 64 connections are usually sufficient.</sys:String>
     <sys:String x:Key="Setup.GameManage.Download.FileConnections">Max connections per file</sys:String>
     <sys:String x:Key="Setup.GameManage.Download.FileConnections.ToolTip">The most connections a large file may use at once. A higher value can help sources that cap each connection, but may also trigger source throttling.</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.HttpProtocol">File download protocol</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.HttpProtocol.Auto">Automatic (recommended)</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.HttpProtocol.Auto.ToolTip">Prefer HTTP/2 for small files and batch downloads, and use HTTP/1.1 for large segmented downloads to balance concurrency and compatibility.</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.HttpProtocol.Http11">HTTP/1.1</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.HttpProtocol.Http11.ToolTip">Force HTTP/1.1 for all file downloads. This can help environments where independent connections improve large-file throughput.</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.HttpProtocol.Http2">Prefer HTTP/2</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.HttpProtocol.Http2.ToolTip">Prefer HTTP/2 for all file downloads, falling back to HTTP/1.1 when the source or proxy does not support it.</sys:String>
     <sys:String x:Key="Setup.GameManage.Download.Unlimited">Unlimited</sys:String>
 
     <!-- Setup.Java -->

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -2672,10 +2672,12 @@
     <sys:String x:Key="Setup.GameManage.Download.SpeedLimit.ToolTip">Set a download speed cap to prevent other programs that depend on the internet from freezing during downloads.</sys:String>
     <sys:String x:Key="Setup.GameManage.Download.TargetFolder">Target folder</sys:String>
     <sys:String x:Key="Setup.GameManage.Download.TargetFolder.Hint">Go to Launch → Selection → Folder list to change the download target folder.&#xA;Right-click a folder or game instance to open the corresponding folder.</sys:String>
-    <sys:String x:Key="Setup.GameManage.Download.Threads">Max threads</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.Threads">Max concurrent connections</sys:String>
     <sys:String x:Key="Setup.GameManage.Download.Threads.TooManyWarning.Confirm">I see</sys:String>
-    <sys:String x:Key="Setup.GameManage.Download.Threads.TooManyWarning.Message">Setting too many download threads may cause serious lag during downloads.&#xA;64 threads are generally enough for most download needs. Unless you know what you are doing, it is not recommended to set a higher value!</sys:String>
-    <sys:String x:Key="Setup.GameManage.Download.Threads.ToolTip">More threads can speed up rate-limited downloads, but too many may cause serious lag during downloads.&#xA;In general, 64 threads are enough for most download needs.</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.Threads.TooManyWarning.Message">A high connection limit can trigger server throttling, network lag, or disk pressure.&#xA;64 connections are usually sufficient unless you know that your sources and network benefit from more.</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.Threads.ToolTip">Limits the total network connections used by all downloads. Segment sizing and slow-connection retries are adjusted automatically; 64 connections are usually sufficient.</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.FileConnections">Max connections per file</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.FileConnections.ToolTip">The most connections a large file may use at once. A higher value can help sources that cap each connection, but may also trigger source throttling.</sys:String>
     <sys:String x:Key="Setup.GameManage.Download.Unlimited">Unlimited</sys:String>
 
     <!-- Setup.Java -->
@@ -3226,7 +3228,7 @@
     <sys:String x:Key="Speed.Error.Copied">Error details copied!</sys:String>
     <sys:String x:Key="Speed.Error.OperationFailed">A task manager operation failed. See the details below.</sys:String>
     <sys:String x:Key="Speed.Progress.RemainingFiles">Remaining files</sys:String>
-    <sys:String x:Key="Speed.Progress.RemainingThreads">Remaining threads</sys:String>
+    <sys:String x:Key="Speed.Progress.RemainingThreads">Active connections</sys:String>
     <sys:String x:Key="Speed.Progress.Speed">Download speed</sys:String>
     <sys:String x:Key="Speed.Progress.Total">Total progress</sys:String>
 

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -2674,8 +2674,8 @@
     <sys:String x:Key="Setup.GameManage.Download.TargetFolder.Hint">Go to Launch → Selection → Folder list to change the download target folder.&#xA;Right-click a folder or game instance to open the corresponding folder.</sys:String>
     <sys:String x:Key="Setup.GameManage.Download.Threads">Max concurrent connections</sys:String>
     <sys:String x:Key="Setup.GameManage.Download.Threads.TooManyWarning.Confirm">I see</sys:String>
-    <sys:String x:Key="Setup.GameManage.Download.Threads.TooManyWarning.Message">A high connection limit can trigger server throttling, network lag, or disk pressure.&#xA;64 connections are usually sufficient unless you know that your sources and network benefit from more.</sys:String>
-    <sys:String x:Key="Setup.GameManage.Download.Threads.ToolTip">Limits the total network connections used by all downloads. Segment sizing and slow-connection retries are adjusted automatically; 64 connections are usually sufficient.</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.Threads.TooManyWarning.Message">A high connection limit can lead to severe lag or even stricter throttling strategies from the server.&#xA;64 connections are usually sufficient. Do not set it higher unless you know what you are doing!</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.Threads.ToolTip">Limits the total network connections used by all download tasks. 64 connections are usually sufficient.</sys:String>
     <sys:String x:Key="Setup.GameManage.Download.FileConnections">Max connections per file</sys:String>
     <sys:String x:Key="Setup.GameManage.Download.FileConnections.ToolTip">The most connections a large file may use at once. A higher value can help sources that cap each connection, but may also trigger source throttling.</sys:String>
     <sys:String x:Key="Setup.GameManage.Download.Unlimited">Unlimited</sys:String>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -2674,10 +2674,10 @@
     <sys:String x:Key="Setup.GameManage.Download.TargetFolder.Hint">请在 启动 → 实例选择 → 文件夹列表 中更改下载目标文件夹。&#xA;在某个文件夹或游戏实例上右键，即可选择打开对应文件夹。</sys:String>
     <sys:String x:Key="Setup.GameManage.Download.Threads">最大并发连接数</sys:String>
     <sys:String x:Key="Setup.GameManage.Download.Threads.TooManyWarning.Confirm">我知道了</sys:String>
-    <sys:String x:Key="Setup.GameManage.Download.Threads.TooManyWarning.Message">过高的并发连接数可能导致服务器限速、网络卡顿或磁盘压力增加。&#xA;64 个连接通常已足够，除非你确认下载源和网络环境能够从更多连接中受益。</sys:String>
-    <sys:String x:Key="Setup.GameManage.Download.Threads.ToolTip">限制所有下载任务合计使用的网络连接数。分段大小和慢速重试会自动调整；64 个连接通常已足够。</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.Threads.TooManyWarning.Message">过高的并发连接数可能导致下载时出现非常严重的卡顿，甚至导致服务器使用更严格的限速策略。&#xA;64 个连接通常已经可以满足需求。除非你知道自己在做什么，否则不建议设置更高的并发连接数！</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.Threads.ToolTip">限制所有下载任务合计使用的网络连接数。64 个连接通常已经足够。</sys:String>
     <sys:String x:Key="Setup.GameManage.Download.FileConnections">单文件最大连接数</sys:String>
-    <sys:String x:Key="Setup.GameManage.Download.FileConnections.ToolTip">大文件最多同时使用的连接数。提高该值可能加快被单连接限速的下载，但也更容易被下载源限速。</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.FileConnections.ToolTip">大文件最多同时使用的连接数。提高该值可能加快被单连接限速的下载，但也有可能更容易被下载源限速。</sys:String>
     <sys:String x:Key="Setup.GameManage.Download.Unlimited">无限制</sys:String>
 
     <!-- Setup.Java -->

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -2672,10 +2672,12 @@
     <sys:String x:Key="Setup.GameManage.Download.SpeedLimit.ToolTip">设置下载的速度上限，以避免在下载时导致其他需要联网的程序卡死</sys:String>
     <sys:String x:Key="Setup.GameManage.Download.TargetFolder">目标文件夹</sys:String>
     <sys:String x:Key="Setup.GameManage.Download.TargetFolder.Hint">请在 启动 → 实例选择 → 文件夹列表 中更改下载目标文件夹。&#xA;在某个文件夹或游戏实例上右键，即可选择打开对应文件夹。</sys:String>
-    <sys:String x:Key="Setup.GameManage.Download.Threads">最大线程数</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.Threads">最大并发连接数</sys:String>
     <sys:String x:Key="Setup.GameManage.Download.Threads.TooManyWarning.Confirm">我知道了</sys:String>
-    <sys:String x:Key="Setup.GameManage.Download.Threads.TooManyWarning.Message">如果设置过多的下载线程，可能会导致下载时出现非常严重的卡顿。&#xA;一般设置 64 线程即可满足大多数下载需求，除非你知道你在干什么，否则不建议设置更多的线程数！</sys:String>
-    <sys:String x:Key="Setup.GameManage.Download.Threads.ToolTip">线程数越多，限速的文件下载越快，但过高的线程数可能会造成下载时非常严重的卡顿。&#xA;一般而言，64 线程已可以保证足够的下载速度。</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.Threads.TooManyWarning.Message">过高的并发连接数可能导致服务器限速、网络卡顿或磁盘压力增加。&#xA;64 个连接通常已足够，除非你确认下载源和网络环境能够从更多连接中受益。</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.Threads.ToolTip">限制所有下载任务合计使用的网络连接数。分段大小和慢速重试会自动调整；64 个连接通常已足够。</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.FileConnections">单文件最大连接数</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.FileConnections.ToolTip">大文件最多同时使用的连接数。提高该值可能加快被单连接限速的下载，但也更容易被下载源限速。</sys:String>
     <sys:String x:Key="Setup.GameManage.Download.Unlimited">无限制</sys:String>
 
     <!-- Setup.Java -->
@@ -3226,7 +3228,7 @@
     <sys:String x:Key="Speed.Error.Copied">已复制错误详情！</sys:String>
     <sys:String x:Key="Speed.Error.OperationFailed">任务管理操作失败。请查看错误详情。</sys:String>
     <sys:String x:Key="Speed.Progress.RemainingFiles">剩余文件</sys:String>
-    <sys:String x:Key="Speed.Progress.RemainingThreads">剩余线程</sys:String>
+    <sys:String x:Key="Speed.Progress.RemainingThreads">活动连接</sys:String>
     <sys:String x:Key="Speed.Progress.Speed">下载速度</sys:String>
     <sys:String x:Key="Speed.Progress.Total">总进度</sys:String>
 

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -2678,6 +2678,13 @@
     <sys:String x:Key="Setup.GameManage.Download.Threads.ToolTip">限制所有下载任务合计使用的网络连接数。64 个连接通常已经足够。</sys:String>
     <sys:String x:Key="Setup.GameManage.Download.FileConnections">单文件最大连接数</sys:String>
     <sys:String x:Key="Setup.GameManage.Download.FileConnections.ToolTip">大文件最多同时使用的连接数。提高该值可能加快被单连接限速的下载，但也有可能更容易被下载源限速。</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.HttpProtocol">文件下载协议</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.HttpProtocol.Auto">自动选择（推荐）</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.HttpProtocol.Auto.ToolTip">小文件和批量下载优先使用 HTTP/2；大文件分段下载使用 HTTP/1.1，以兼顾并发和兼容性。</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.HttpProtocol.Http11">HTTP/1.1</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.HttpProtocol.Http11.ToolTip">所有文件下载强制使用 HTTP/1.1。适合需要多条独立连接提升大文件速度的网络环境。</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.HttpProtocol.Http2">优先使用 HTTP/2</sys:String>
+    <sys:String x:Key="Setup.GameManage.Download.HttpProtocol.Http2.ToolTip">所有文件下载优先使用 HTTP/2；如果下载源或代理不支持，会自动回退到 HTTP/1.1。</sys:String>
     <sys:String x:Key="Setup.GameManage.Download.Unlimited">无限制</sys:String>
 
     <!-- Setup.Java -->

--- a/PCL.Core/IO/Net/NetworkService.cs
+++ b/PCL.Core/IO/Net/NetworkService.cs
@@ -143,6 +143,7 @@ public partial class NetworkService
         AllowAutoRedirect = true,
         MaxAutomaticRedirections = 20,
         UseCookies = false,
+        EnableMultipleHttp2Connections = true,
         ConnectCallback = Config.Network.EnableDoH ? HostConnectionHandler.Instance.GetConnectionAsync : null
     };
 

--- a/Plain Craft Launcher 2/Modules/Base/ModSetup.cs
+++ b/Plain Craft Launcher 2/Modules/Base/ModSetup.cs
@@ -31,6 +31,8 @@ public class ModSetup
         // === Tool ===
         Config.Download.ThreadLimitConfig.Observe(new ConfigObserver(ConfigEvent.Changed,
             e => ToolDownloadThread((int)e.Value!)));
+        Config.Download.FileConnectionLimitConfig.Observe(new ConfigObserver(ConfigEvent.Changed,
+            e => ToolDownloadFileConnection((int)e.Value!)));
         Config.Download.SpeedLimitConfig.Observe(new ConfigObserver(ConfigEvent.Changed,
             e => ToolDownloadSpeed((int)e.Value!)));
 
@@ -113,6 +115,7 @@ public class ModSetup
 
         // Tool
         ToolDownloadThread(Config.Download.ThreadLimit);
+        ToolDownloadFileConnection(Config.Download.FileConnectionLimit);
         ToolDownloadSpeed(Config.Download.SpeedLimit);
 
         // UI - Launcher
@@ -195,7 +198,13 @@ public class ModSetup
 
     public static void ToolDownloadThread(int value)
     {
-        ModNet.NetTaskThreadLimit = value + 1;
+        ModNet.NetTaskConnectionLimit = Math.Clamp(value + 1, 1, ModNet.NetTaskConnectionLimitMax);
+    }
+
+    public static void ToolDownloadFileConnection(int value)
+    {
+        ModNet.NetTaskSingleFileConnectionLimit = Math.Clamp(value + 1, 1,
+            ModNet.NetTaskSingleFileConnectionLimitMax);
     }
 
     public static void ToolDownloadSpeed(int value)

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.cs
@@ -64,8 +64,10 @@ public static class ModDownload
         var indexUrl = (string)(indexInfo["url"] ?? "");
         if (string.IsNullOrEmpty(indexUrl)) return null;
 
+        // 避免下载器先发一次 Range 探测请求，再回退到顺序下载
+        var indexSize = indexInfo["size"] is null ? -1L : (long)indexInfo["size"];
         return new DownloadFile(DlSourceLauncherOrMetaGet(indexUrl), indexAddress,
-            new ModBase.FileChecker(canUseExistsFile: false));
+            new ModBase.FileChecker(actualSize: indexSize, canUseExistsFile: false));
     }
 
     /// <summary>

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModSkin.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModSkin.cs
@@ -153,9 +153,7 @@ public static class ModSkin
         {
             if (!File.Exists(fileAddress))
             {
-                FileDownloader.DownloadAsync(address, fileAddress + ModNet.NetDownloadEnd).GetAwaiter().GetResult();
-                File.Delete(fileAddress);
-                FileSystem.Rename(fileAddress + ModNet.NetDownloadEnd, fileAddress);
+                FileDownloader.DownloadAsync(address, fileAddress).GetAwaiter().GetResult();
                 ModBase.Log("[Minecraft] 皮肤下载成功：" + fileAddress);
             }
 

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModSkin.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModSkin.cs
@@ -153,9 +153,9 @@ public static class ModSkin
         {
             if (!File.Exists(fileAddress))
             {
-                FileDownloader.DownloadAsync(address, fileAddress + ModNet.netDownloadEnd).GetAwaiter().GetResult();
+                FileDownloader.DownloadAsync(address, fileAddress + ModNet.NetDownloadEnd).GetAwaiter().GetResult();
                 File.Delete(fileAddress);
-                FileSystem.Rename(fileAddress + ModNet.netDownloadEnd, fileAddress);
+                FileSystem.Rename(fileAddress + ModNet.NetDownloadEnd, fileAddress);
                 ModBase.Log("[Minecraft] 皮肤下载成功：" + fileAddress);
             }
 

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/AdaptiveRangeDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/AdaptiveRangeDownloader.cs
@@ -1,0 +1,420 @@
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Channels;
+using Microsoft.Win32.SafeHandles;
+
+namespace PCL.Network;
+
+/// <summary>为支持 HTTP Range 的大文件提供动态分段下载与慢连接恢复。</summary>
+internal sealed class AdaptiveRangeDownloader
+{
+    private const long SmallFileThreshold = 32L * 1024 * 1024;
+    private const long TargetSegmentSize = 8L * 1024 * 1024;
+    private const int MaxSegmentCount = 1024;
+    private const int MaxExpandedSegmentCount = MaxSegmentCount * 2;
+    private const int BufferSize = 64 * 1024;
+    private const int ReadTimeoutMilliseconds = 15_000;
+    private const int SlowCheckSeconds = 8;
+    private const long SlowSplitThreshold = 2L * 1024 * 1024;
+    private const long MinimumRestartRemaining = 1L * 1024 * 1024;
+    private const int MaxSegmentRetries = 2;
+
+    private readonly string _url;
+    private readonly string _tempPath;
+    private readonly bool _useBrowserUserAgent;
+    private readonly string _customUserAgent;
+    private readonly DownloadFile? _trackedFile;
+
+    private AdaptiveRangeDownloader(string url, string localPath, bool useBrowserUserAgent, string customUserAgent,
+        DownloadFile? trackedFile)
+    {
+        _url = url;
+        _tempPath = localPath + ModNet.NetDownloadEnd;
+        _useBrowserUserAgent = useBrowserUserAgent;
+        _customUserAgent = customUserAgent;
+        _trackedFile = trackedFile;
+    }
+
+    /// <summary>若文件适合 Range 分段下载则完成下载并返回 true，否则返回 false 交给顺序下载器处理。</summary>
+    public static async Task<bool> TryDownloadAsync(string url, string localPath, bool useBrowserUserAgent,
+        string customUserAgent, CancellationToken cancellationToken, DownloadFile? trackedFile)
+    {
+        var downloader = new AdaptiveRangeDownloader(url, localPath, useBrowserUserAgent, customUserAgent, trackedFile);
+        var probe = await downloader.ProbeAsync(cancellationToken).ConfigureAwait(false);
+        if (probe is null || probe.Value.Size < SmallFileThreshold)
+            return false;
+
+        await downloader.DownloadAsync(probe.Value.Size, cancellationToken).ConfigureAwait(false);
+        return true;
+    }
+
+    private async Task<RangeProbe?> ProbeAsync(CancellationToken cancellationToken)
+    {
+        using var connection = await DownloadResourceManager.AcquireConnectionAsync(_url, cancellationToken)
+            .ConfigureAwait(false);
+        using var request = CreateRequest(HttpMethod.Get);
+        request.Headers.Range = new RangeHeaderValue(0, 0);
+        using var response = await FileDownloader.GetHttpClient(_url)
+            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+
+        if (response.StatusCode != HttpStatusCode.PartialContent)
+            return null;
+
+        var range = response.Content.Headers.ContentRange;
+        if (range?.Unit != "bytes" || range.From != 0 || range.To != 0 || range.Length is not > 0)
+            return null;
+
+        return new RangeProbe(range.Length.Value);
+    }
+
+    private async Task DownloadAsync(long totalSize, CancellationToken cancellationToken)
+    {
+        NotifyStarted(totalSize);
+        var segments = Channel.CreateUnbounded<DownloadSegment>(new UnboundedChannelOptions
+        {
+            SingleReader = false,
+            SingleWriter = false,
+            AllowSynchronousContinuations = false
+        });
+
+        var segmentCount = EnqueueInitialSegments(segments.Writer, totalSize);
+        var workerCount = Math.Min(segmentCount, Math.Clamp(ModNet.NetTaskSingleFileConnectionLimit, 1,
+            ModNet.NetTaskSingleFileConnectionLimitMax));
+        using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        await using var output = new FileStream(_tempPath, FileMode.Create, FileAccess.Write, FileShare.Read,
+            bufferSize: 1, FileOptions.Asynchronous | FileOptions.RandomAccess);
+        output.SetLength(totalSize);
+
+        var session = new DownloadSession(this, segments, totalSize, segmentCount, output.SafeFileHandle,
+            linkedCancellation);
+        var workers = Enumerable.Range(0, workerCount).Select(_ => session.RunWorkerAsync()).ToArray();
+        try
+        {
+            await Task.WhenAll(workers).ConfigureAwait(false);
+            await output.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            segments.Writer.TryComplete();
+        }
+
+        if (session.DownloadedBytes != totalSize)
+            throw new IOException($"分段下载不完整：已写入 {session.DownloadedBytes}，应为 {totalSize}");
+
+        NotifyProgress(totalSize, 0, force: true);
+    }
+
+    private int EnqueueInitialSegments(ChannelWriter<DownloadSegment> writer, long totalSize)
+    {
+        var count = (int)Math.Clamp((totalSize + TargetSegmentSize - 1) / TargetSegmentSize, 1, MaxSegmentCount);
+        var segmentSize = (totalSize + count - 1) / count;
+        var id = 0;
+        for (long start = 0; start < totalSize; start += segmentSize)
+        {
+            var end = Math.Min(totalSize - 1, start + segmentSize - 1);
+            writer.TryWrite(new DownloadSegment(Interlocked.Increment(ref id), start, end));
+        }
+
+        return id;
+    }
+
+    private HttpRequestMessage CreateRequest(HttpMethod method)
+    {
+        var request = FileDownloader.CreateDownloadRequest(_url, _useBrowserUserAgent, _customUserAgent);
+        request.Method = method;
+        request.Headers.AcceptEncoding.Clear();
+        request.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("identity"));
+        return request;
+    }
+
+    private void NotifyStarted(long totalSize)
+    {
+        if (_trackedFile is null)
+            return;
+
+        _trackedFile.State = NetState.Downloading;
+        _trackedFile.TotalSize = totalSize;
+        _trackedFile.IsUnknownSize = false;
+        _trackedFile.DownloadedBytes = 0;
+        _trackedFile.Speed = 0;
+        _trackedFile.ActiveThreads = 0;
+    }
+
+    private void NotifyProgress(long downloaded, int activeConnections, bool force = false)
+    {
+        if (_trackedFile is null)
+            return;
+
+        _trackedFile.State = NetState.Downloading;
+        _trackedFile.DownloadedBytes = downloaded;
+        _trackedFile.ActiveThreads = activeConnections;
+    }
+
+    private readonly record struct RangeProbe(long Size);
+
+    private sealed class DownloadSegment(int id, long start, long end)
+    {
+        public int Id { get; } = id;
+        public long Start { get; } = start;
+        public long End { get; set; } = end;
+        public long Downloaded { get; set; }
+        public int FailureCount { get; set; }
+        public long Remaining => End - Start - Downloaded + 1;
+        public long CurrentOffset => Start + Downloaded;
+    }
+
+    private sealed class DownloadSession
+    {
+        private readonly AdaptiveRangeDownloader _owner;
+        private readonly Channel<DownloadSegment> _segments;
+        private readonly long _totalSize;
+        private readonly SafeFileHandle _fileHandle;
+        private readonly CancellationTokenSource _cancellation;
+        private readonly ConcurrentDictionary<int, RateSample> _rates = new();
+        // 尾段可能已没有其他活跃连接，保留近期完成分段作为比较基线。
+        private readonly ConcurrentQueue<double> _completedRates = new();
+        private readonly object _progressLock = new();
+        private int _outstandingSegments;
+        private int _nextSegmentId;
+        private int _activeConnections;
+        private long _downloadedBytes;
+        private long _lastProgressBytes;
+        private long _lastProgressTick = Stopwatch.GetTimestamp();
+        private Exception? _failure;
+
+        public DownloadSession(AdaptiveRangeDownloader owner, Channel<DownloadSegment> segments, long totalSize,
+            int segmentCount, SafeFileHandle fileHandle, CancellationTokenSource cancellation)
+        {
+            _owner = owner;
+            _segments = segments;
+            _totalSize = totalSize;
+            _outstandingSegments = segmentCount;
+            _nextSegmentId = segmentCount;
+            _fileHandle = fileHandle;
+            _cancellation = cancellation;
+        }
+
+        public long DownloadedBytes => Interlocked.Read(ref _downloadedBytes);
+
+        public async Task RunWorkerAsync()
+        {
+            try
+            {
+                while (await _segments.Reader.WaitToReadAsync(_cancellation.Token).ConfigureAwait(false))
+                {
+                    while (_segments.Reader.TryRead(out var segment))
+                    {
+                        try
+                        {
+                            await DownloadSegmentAsync(segment, _cancellation.Token).ConfigureAwait(false);
+                            if (Interlocked.Decrement(ref _outstandingSegments) == 0)
+                                _segments.Writer.TryComplete();
+                        }
+                        catch (OperationCanceledException) when (_cancellation.IsCancellationRequested)
+                        {
+                            throw;
+                        }
+                        catch (Exception ex)
+                        {
+                            if (TryRecover(segment, ex))
+                            {
+                                ModBase.Log(ex, $"[Download] 分段下载缓慢或失败，正在重试：{_owner._url}", ModBase.LogLevel.Debug);
+                                await Task.Delay(Random.Shared.Next(250, 1001), _cancellation.Token).ConfigureAwait(false);
+                                continue;
+                            }
+
+                            Interlocked.CompareExchange(ref _failure, ex, null);
+                            _segments.Writer.TryComplete(ex);
+                            _cancellation.Cancel();
+                            throw;
+                        }
+                    }
+                }
+            }
+            catch (OperationCanceledException) when (_failure is not null)
+            {
+                throw _failure;
+            }
+        }
+
+        private bool TryRecover(DownloadSegment segment, Exception exception)
+        {
+            if (exception is not (SlowSegmentException or IOException or HttpRequestException or TaskCanceledException))
+                return false;
+            if (++segment.FailureCount > MaxSegmentRetries || segment.Remaining <= 0)
+                return false;
+
+            if (segment.Remaining >= SlowSplitThreshold && Volatile.Read(ref _nextSegmentId) < MaxExpandedSegmentCount)
+            {
+                var splitStart = segment.CurrentOffset + segment.Remaining / 2;
+                var split = new DownloadSegment(Interlocked.Increment(ref _nextSegmentId), splitStart, segment.End);
+                segment.End = splitStart - 1;
+                _segments.Writer.TryWrite(segment);
+                _segments.Writer.TryWrite(split);
+                Interlocked.Increment(ref _outstandingSegments);
+            }
+            else
+            {
+                _segments.Writer.TryWrite(segment);
+            }
+
+            return true;
+        }
+
+        private async Task DownloadSegmentAsync(DownloadSegment segment, CancellationToken cancellationToken)
+        {
+            using var connection = await DownloadResourceManager.AcquireConnectionAsync(_owner._url, cancellationToken)
+                .ConfigureAwait(false);
+            var activeConnections = Interlocked.Increment(ref _activeConnections);
+            var startedAt = Stopwatch.GetTimestamp();
+            var attemptBytes = 0L;
+            try
+            {
+                using var request = _owner.CreateRequest(HttpMethod.Get);
+                request.Headers.Range = new RangeHeaderValue(segment.CurrentOffset, segment.End);
+                using var response = await FileDownloader.GetHttpClient(_owner._url)
+                    .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                ValidateRangeResponse(response, segment);
+
+                await using var input = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+                while (segment.Remaining > 0)
+                {
+                    using var bufferLease = await DownloadResourceManager.ReserveBufferAsync(BufferSize, cancellationToken)
+                        .ConfigureAwait(false);
+                    var buffer = ArrayPool<byte>.Shared.Rent(BufferSize);
+                    try
+                    {
+                        int read;
+                        using (var readTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+                        {
+                            readTimeout.CancelAfter(ReadTimeoutMilliseconds);
+                            try
+                            {
+                                read = await input.ReadAsync(buffer.AsMemory(0, BufferSize), readTimeout.Token)
+                                    .ConfigureAwait(false);
+                            }
+                            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested &&
+                                                                   readTimeout.IsCancellationRequested)
+                            {
+                                throw new SlowSegmentException("分段在等待数据时超时");
+                            }
+                        }
+
+                        if (read == 0)
+                            break;
+                        read = (int)Math.Min(read, segment.Remaining);
+
+                        await DownloadResourceManager.ThrottleAsync(read, cancellationToken).ConfigureAwait(false);
+                        await RandomAccess.WriteAsync(_fileHandle, buffer.AsMemory(0, read), segment.CurrentOffset,
+                            cancellationToken).ConfigureAwait(false);
+
+                        segment.Downloaded += read;
+                        attemptBytes += read;
+                        var downloaded = Interlocked.Add(ref _downloadedBytes, read);
+                        ReportRateAndProgress(segment, attemptBytes, startedAt, downloaded, activeConnections);
+                    }
+                    finally
+                    {
+                        ArrayPool<byte>.Shared.Return(buffer);
+                    }
+                }
+
+                if (segment.Remaining > 0)
+                    throw new IOException($"分段 {segment.Id} 提前结束，还剩 {segment.Remaining} 字节");
+
+                AddCompletedRate(attemptBytes, startedAt);
+            }
+            finally
+            {
+                _rates.TryRemove(segment.Id, out _);
+                activeConnections = Interlocked.Decrement(ref _activeConnections);
+                ReportProgress(Interlocked.Read(ref _downloadedBytes), activeConnections, force: true);
+            }
+        }
+
+        private void ReportRateAndProgress(DownloadSegment segment, long attemptBytes, long startedAt, long downloaded,
+            int activeConnections)
+        {
+            var now = Stopwatch.GetTimestamp();
+            var elapsedSeconds = Math.Max(0.001, (double)(now - startedAt) / Stopwatch.Frequency);
+            _rates[segment.Id] = new RateSample(attemptBytes / elapsedSeconds, now);
+
+            if (IsSignificantlySlow(segment, attemptBytes, startedAt, now))
+                throw new SlowSegmentException("分段速度明显低于其他活跃连接");
+
+            ReportProgress(downloaded, activeConnections);
+        }
+
+        private bool IsSignificantlySlow(DownloadSegment segment, long attemptBytes, long startedAt, long now)
+        {
+            if (ModNet.NetTaskSpeedLimitHigh > 0 || segment.Remaining < MinimumRestartRemaining)
+                return false;
+
+            var elapsedSeconds = (double)(now - startedAt) / Stopwatch.Frequency;
+            if (elapsedSeconds < SlowCheckSeconds)
+                return false;
+
+            var rates = _rates.Where(pair => pair.Key != segment.Id &&
+                                             now - pair.Value.UpdatedAt <= Stopwatch.Frequency * 2 &&
+                                             pair.Value.BytesPerSecond > 0)
+                .Select(pair => pair.Value.BytesPerSecond)
+                .ToArray();
+            if (rates.Length == 0)
+                rates = _completedRates.Where(rate => rate > 0).ToArray();
+            if (rates.Length == 0)
+                return false;
+
+            Array.Sort(rates);
+            var median = rates[rates.Length / 2];
+            var ownRate = attemptBytes / elapsedSeconds;
+            return median >= 128 * 1024 && ownRate * 4 < median;
+        }
+
+        private void AddCompletedRate(long attemptBytes, long startedAt)
+        {
+            var elapsedSeconds = Math.Max(0.001, (double)(Stopwatch.GetTimestamp() - startedAt) / Stopwatch.Frequency);
+            _completedRates.Enqueue(attemptBytes / elapsedSeconds);
+            while (_completedRates.Count > 8)
+                _completedRates.TryDequeue(out _);
+        }
+
+        private void ReportProgress(long downloaded, int activeConnections, bool force = false)
+        {
+            lock (_progressLock)
+            {
+                var now = Stopwatch.GetTimestamp();
+                if (!force && now - _lastProgressTick < Stopwatch.Frequency / 5)
+                    return;
+
+                var elapsed = Math.Max(1L, now - _lastProgressTick);
+                var speed = Math.Max(0L, (long)((downloaded - _lastProgressBytes) * (double)Stopwatch.Frequency / elapsed));
+                _owner.NotifyProgress(downloaded, activeConnections, force);
+                if (_owner._trackedFile is not null)
+                    _owner._trackedFile.Speed = speed;
+
+                _lastProgressBytes = downloaded;
+                _lastProgressTick = now;
+            }
+        }
+
+        private void ValidateRangeResponse(HttpResponseMessage response, DownloadSegment segment)
+        {
+            if (response.StatusCode != HttpStatusCode.PartialContent)
+                throw new IOException($"服务器未按 Range 返回分段，状态码：{(int)response.StatusCode}");
+
+            var range = response.Content.Headers.ContentRange;
+            if (range?.Unit != "bytes" || range.From != segment.CurrentOffset || range.To != segment.End ||
+                range.Length != _totalSize)
+                throw new IOException("服务器返回的 Content-Range 与请求分段不一致");
+        }
+
+        private readonly record struct RateSample(double BytesPerSecond, long UpdatedAt);
+    }
+
+    private sealed class SlowSegmentException(string message) : IOException(message);
+}

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/AdaptiveRangeDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/AdaptiveRangeDownloader.cs
@@ -42,8 +42,13 @@ internal sealed class AdaptiveRangeDownloader
 
     /// <summary>若文件适合 Range 分段下载则完成下载并返回 true，否则返回 false 交给顺序下载器处理。</summary>
     public static async Task<bool> TryDownloadAsync(string url, string localPath, bool useBrowserUserAgent,
-        string customUserAgent, CancellationToken cancellationToken, DownloadFile? trackedFile)
+        string customUserAgent, CancellationToken cancellationToken, DownloadFile? trackedFile,
+        long expectedSize = -1)
     {
+        // 下载清单已有大小时，小文件直接走顺序请求，避免额外的 Range 探测往返。
+        if (expectedSize >= 0 && expectedSize < SmallFileThreshold)
+            return false;
+
         var downloader = new AdaptiveRangeDownloader(url, localPath, useBrowserUserAgent, customUserAgent, trackedFile);
         var probe = await downloader.ProbeAsync(cancellationToken).ConfigureAwait(false);
         if (probe is null || probe.Value.Size < SmallFileThreshold)

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/AdaptiveRangeDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/AdaptiveRangeDownloader.cs
@@ -302,19 +302,19 @@ internal sealed class AdaptiveRangeDownloader
 
                 await using var input = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
                 using var readTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                while (segment.Remaining > 0)
+                using var bufferLease = await DownloadResourceManager.ReserveBufferAsync(BufferSize, cancellationToken)
+                    .ConfigureAwait(false);
+                var buffer = ArrayPool<byte>.Shared.Rent(BufferSize);
+                try
                 {
-                    using var bufferLease = await DownloadResourceManager.ReserveBufferAsync(BufferSize, cancellationToken)
-                        .ConfigureAwait(false);
-                    var buffer = ArrayPool<byte>.Shared.Rent(BufferSize);
-                    try
+                    while (segment.Remaining > 0)
                     {
                         int read;
                         readTimeout.CancelAfter(ReadTimeoutMilliseconds);
                         try
                         {
                             read = await input.ReadAsync(buffer.AsMemory(0, BufferSize), readTimeout.Token)
-                                .ConfigureAwait(false);
+                                    .ConfigureAwait(false);
                         }
                         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested &&
                                                                readTimeout.IsCancellationRequested)
@@ -335,10 +335,10 @@ internal sealed class AdaptiveRangeDownloader
                         var downloaded = Interlocked.Add(ref _downloadedBytes, read);
                         ReportRateAndProgress(segment, attemptBytes, startedAt, downloaded);
                     }
-                    finally
-                    {
-                        ArrayPool<byte>.Shared.Return(buffer);
-                    }
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(buffer);
                 }
 
                 if (segment.Remaining > 0)

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/AdaptiveRangeDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/AdaptiveRangeDownloader.cs
@@ -75,7 +75,7 @@ internal sealed class AdaptiveRangeDownloader
     {
         using var connection = await DownloadResourceManager.AcquireConnectionAsync(_url, cancellationToken)
             .ConfigureAwait(false);
-        using var request = CreateRequest(HttpMethod.Get);
+        using var request = CreateRequest(HttpMethod.Get, DownloadRequestKind.RangeProbe);
         request.Headers.Range = new RangeHeaderValue(0, 0);
         using var response = await FileDownloader.GetHttpClient(_url)
             .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
@@ -141,9 +141,9 @@ internal sealed class AdaptiveRangeDownloader
         return id;
     }
 
-    private HttpRequestMessage CreateRequest(HttpMethod method)
+    private HttpRequestMessage CreateRequest(HttpMethod method, DownloadRequestKind requestKind)
     {
-        var request = FileDownloader.CreateDownloadRequest(_url, _useBrowserUserAgent, _customUserAgent);
+        var request = FileDownloader.CreateDownloadRequest(_url, _useBrowserUserAgent, _customUserAgent, requestKind);
         request.Method = method;
         request.Headers.AcceptEncoding.Clear();
         request.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("identity"));
@@ -294,7 +294,7 @@ internal sealed class AdaptiveRangeDownloader
             var attemptBytes = 0L;
             try
             {
-                using var request = _owner.CreateRequest(HttpMethod.Get);
+                using var request = _owner.CreateRequest(HttpMethod.Get, DownloadRequestKind.RangeSegment);
                 request.Headers.Range = new RangeHeaderValue(segment.CurrentOffset, segment.End);
                 using var response = await FileDownloader.GetHttpClient(_owner._url)
                     .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/AdaptiveRangeDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/AdaptiveRangeDownloader.cs
@@ -20,6 +20,8 @@ internal sealed class AdaptiveRangeDownloader
     private const int BufferSize = 64 * 1024;
     private const int ReadTimeoutMilliseconds = 15_000;
     private const int SlowCheckSeconds = 8;
+    private const long SlowSpeedBytesPerSecond = 50L * 1024;
+    private const long ClearlyFastSegmentBytesPerSecond = 128L * 1024;
     private const long SlowSplitThreshold = 2L * 1024 * 1024;
     private const long MinimumRestartRemaining = 1L * 1024 * 1024;
     private const int MaxSegmentRetries = 2;
@@ -392,8 +394,14 @@ internal sealed class AdaptiveRangeDownloader
 
             Array.Sort(rates);
             var median = rates[rates.Length / 2];
+            var fastest = rates[^1];
             var ownRate = attemptBytes / elapsedSeconds;
-            return median >= 128 * 1024 && ownRate * 4 < median;
+
+            // 确保至少一个分片的速度更高，当所有连接都被同一个源限速时，不会让所有分片一起反复重启
+            var hasClearlyFasterSegment = fastest >= ClearlyFastSegmentBytesPerSecond && ownRate * 4 < fastest;
+            var relativelySlow = median >= ClearlyFastSegmentBytesPerSecond && ownRate * 4 < median;
+            var absolutelySlow = ownRate < SlowSpeedBytesPerSecond && hasClearlyFasterSegment;
+            return relativelySlow || absolutelySlow;
         }
 
         private void AddCompletedRate(long attemptBytes, long startedAt)

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/AdaptiveRangeDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/AdaptiveRangeDownloader.cs
@@ -13,7 +13,7 @@ namespace PCL.Network;
 /// <summary>为支持 HTTP Range 的大文件提供动态分段下载与慢连接恢复。</summary>
 internal sealed class AdaptiveRangeDownloader
 {
-    internal const long SmallFileThreshold = 32L * 1024 * 1024;
+    internal const long SmallFileThreshold = 4L * 1024 * 1024;
     private const long TargetSegmentSize = 8L * 1024 * 1024;
     private const int MaxSegmentCount = 1024;
     private const int MaxExpandedSegmentCount = MaxSegmentCount * 2;

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/AdaptiveRangeDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/AdaptiveRangeDownloader.cs
@@ -329,6 +329,7 @@ internal sealed class AdaptiveRangeDownloader
                         await DownloadResourceManager.ThrottleAsync(read, cancellationToken).ConfigureAwait(false);
                         await RandomAccess.WriteAsync(_fileHandle, buffer.AsMemory(0, read), segment.CurrentOffset,
                             cancellationToken).ConfigureAwait(false);
+                        DownloadResourceManager.RecordDownloadedBytes(read);
 
                         segment.Downloaded += read;
                         attemptBytes += read;

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/AdaptiveRangeDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/AdaptiveRangeDownloader.cs
@@ -13,7 +13,7 @@ namespace PCL.Network;
 /// <summary>为支持 HTTP Range 的大文件提供动态分段下载与慢连接恢复。</summary>
 internal sealed class AdaptiveRangeDownloader
 {
-    private const long SmallFileThreshold = 32L * 1024 * 1024;
+    internal const long SmallFileThreshold = 32L * 1024 * 1024;
     private const long TargetSegmentSize = 8L * 1024 * 1024;
     private const int MaxSegmentCount = 1024;
     private const int MaxExpandedSegmentCount = MaxSegmentCount * 2;
@@ -169,6 +169,7 @@ internal sealed class AdaptiveRangeDownloader
         public long End { get; set; } = end;
         public long Downloaded { get; set; }
         public int FailureCount { get; set; }
+        public long LastRateSampleTick { get; set; }
         public long Remaining => End - Start - Downloaded + 1;
         public long CurrentOffset => Start + Downloaded;
     }
@@ -287,6 +288,7 @@ internal sealed class AdaptiveRangeDownloader
                 ValidateRangeResponse(response, segment);
 
                 await using var input = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+                using var readTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 while (segment.Remaining > 0)
                 {
                     using var bufferLease = await DownloadResourceManager.ReserveBufferAsync(BufferSize, cancellationToken)
@@ -295,19 +297,16 @@ internal sealed class AdaptiveRangeDownloader
                     try
                     {
                         int read;
-                        using (var readTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+                        readTimeout.CancelAfter(ReadTimeoutMilliseconds);
+                        try
                         {
-                            readTimeout.CancelAfter(ReadTimeoutMilliseconds);
-                            try
-                            {
-                                read = await input.ReadAsync(buffer.AsMemory(0, BufferSize), readTimeout.Token)
-                                    .ConfigureAwait(false);
-                            }
-                            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested &&
-                                                                   readTimeout.IsCancellationRequested)
-                            {
-                                throw new SlowSegmentException("分段在等待数据时超时");
-                            }
+                            read = await input.ReadAsync(buffer.AsMemory(0, BufferSize), readTimeout.Token)
+                                .ConfigureAwait(false);
+                        }
+                        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested &&
+                                                               readTimeout.IsCancellationRequested)
+                        {
+                            throw new SlowSegmentException("分段在等待数据时超时");
                         }
 
                         if (read == 0)
@@ -347,10 +346,14 @@ internal sealed class AdaptiveRangeDownloader
         {
             var now = Stopwatch.GetTimestamp();
             var elapsedSeconds = Math.Max(0.001, (double)(now - startedAt) / Stopwatch.Frequency);
-            _rates[segment.Id] = new RateSample(attemptBytes / elapsedSeconds, now);
+            if (now - segment.LastRateSampleTick >= Stopwatch.Frequency / 2)
+            {
+                segment.LastRateSampleTick = now;
+                _rates[segment.Id] = new RateSample(attemptBytes / elapsedSeconds, now);
 
-            if (IsSignificantlySlow(segment, attemptBytes, startedAt, now))
-                throw new SlowSegmentException("分段速度明显低于其他活跃连接");
+                if (IsSignificantlySlow(segment, attemptBytes, startedAt, now))
+                    throw new SlowSegmentException("分段速度明显低于其他活跃连接");
+            }
 
             ReportProgress(downloaded, activeConnections);
         }

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/AdaptiveRangeDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/AdaptiveRangeDownloader.cs
@@ -77,8 +77,8 @@ internal sealed class AdaptiveRangeDownloader
             .ConfigureAwait(false);
         using var request = CreateRequest(HttpMethod.Get, DownloadRequestKind.RangeProbe);
         request.Headers.Range = new RangeHeaderValue(0, 0);
-        using var response = await FileDownloader.GetHttpClient(_url)
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        using var response = await FileDownloader.SendDownloadRequestAsync(_url, request, cancellationToken)
+            .ConfigureAwait(false);
 
         if (response.StatusCode != HttpStatusCode.PartialContent)
             return null;
@@ -296,8 +296,8 @@ internal sealed class AdaptiveRangeDownloader
             {
                 using var request = _owner.CreateRequest(HttpMethod.Get, DownloadRequestKind.RangeSegment);
                 request.Headers.Range = new RangeHeaderValue(segment.CurrentOffset, segment.End);
-                using var response = await FileDownloader.GetHttpClient(_owner._url)
-                    .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                using var response = await FileDownloader.SendDownloadRequestAsync(_owner._url, request,
+                    cancellationToken).ConfigureAwait(false);
                 ValidateRangeResponse(response, segment);
 
                 await using var input = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/AdaptiveRangeDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/AdaptiveRangeDownloader.cs
@@ -265,7 +265,8 @@ internal sealed class AdaptiveRangeDownloader
 
         private bool TryRecover(DownloadSegment segment, Exception exception)
         {
-            if (exception is not (SlowSegmentException or IOException or HttpRequestException or TaskCanceledException))
+            if (exception is not (SlowSegmentException or IOException or HttpRequestException or TaskCanceledException or
+                DownloadRequestTimeoutException))
                 return false;
             if (++segment.FailureCount > MaxSegmentRetries || segment.Remaining <= 0)
                 return false;

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/AdaptiveRangeDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/AdaptiveRangeDownloader.cs
@@ -50,12 +50,25 @@ internal sealed class AdaptiveRangeDownloader
             return false;
 
         var downloader = new AdaptiveRangeDownloader(url, localPath, useBrowserUserAgent, customUserAgent, trackedFile);
-        var probe = await downloader.ProbeAsync(cancellationToken).ConfigureAwait(false);
-        if (probe is null || probe.Value.Size < SmallFileThreshold)
-            return false;
+        var totalSize = expectedSize;
+        if (totalSize < 0)
+        {
+            var probe = await downloader.ProbeAsync(cancellationToken).ConfigureAwait(false);
+            if (probe is null || probe.Value.Size < SmallFileThreshold)
+                return false;
+            totalSize = probe.Value.Size;
+        }
 
-        await downloader.DownloadAsync(probe.Value.Size, cancellationToken).ConfigureAwait(false);
-        return true;
+        try
+        {
+            await downloader.DownloadAsync(totalSize, cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (RangeNotSupportedException ex)
+        {
+            ModBase.Log(ex, $"[Download] 下载源不支持可靠的 Range，改用顺序下载：{url}", ModBase.LogLevel.Debug);
+            return false;
+        }
     }
 
     private async Task<RangeProbe?> ProbeAsync(CancellationToken cancellationToken)
@@ -276,7 +289,7 @@ internal sealed class AdaptiveRangeDownloader
         {
             using var connection = await DownloadResourceManager.AcquireConnectionAsync(_owner._url, cancellationToken)
                 .ConfigureAwait(false);
-            var activeConnections = Interlocked.Increment(ref _activeConnections);
+            Interlocked.Increment(ref _activeConnections);
             var startedAt = Stopwatch.GetTimestamp();
             var attemptBytes = 0L;
             try
@@ -320,7 +333,7 @@ internal sealed class AdaptiveRangeDownloader
                         segment.Downloaded += read;
                         attemptBytes += read;
                         var downloaded = Interlocked.Add(ref _downloadedBytes, read);
-                        ReportRateAndProgress(segment, attemptBytes, startedAt, downloaded, activeConnections);
+                        ReportRateAndProgress(segment, attemptBytes, startedAt, downloaded);
                     }
                     finally
                     {
@@ -336,13 +349,12 @@ internal sealed class AdaptiveRangeDownloader
             finally
             {
                 _rates.TryRemove(segment.Id, out _);
-                activeConnections = Interlocked.Decrement(ref _activeConnections);
+                var activeConnections = Interlocked.Decrement(ref _activeConnections);
                 ReportProgress(Interlocked.Read(ref _downloadedBytes), activeConnections, force: true);
             }
         }
 
-        private void ReportRateAndProgress(DownloadSegment segment, long attemptBytes, long startedAt, long downloaded,
-            int activeConnections)
+        private void ReportRateAndProgress(DownloadSegment segment, long attemptBytes, long startedAt, long downloaded)
         {
             var now = Stopwatch.GetTimestamp();
             var elapsedSeconds = Math.Max(0.001, (double)(now - startedAt) / Stopwatch.Frequency);
@@ -355,7 +367,7 @@ internal sealed class AdaptiveRangeDownloader
                     throw new SlowSegmentException("分段速度明显低于其他活跃连接");
             }
 
-            ReportProgress(downloaded, activeConnections);
+            ReportProgress(downloaded, Volatile.Read(ref _activeConnections));
         }
 
         private bool IsSignificantlySlow(DownloadSegment segment, long attemptBytes, long startedAt, long now)
@@ -413,16 +425,17 @@ internal sealed class AdaptiveRangeDownloader
         private void ValidateRangeResponse(HttpResponseMessage response, DownloadSegment segment)
         {
             if (response.StatusCode != HttpStatusCode.PartialContent)
-                throw new IOException($"服务器未按 Range 返回分段，状态码：{(int)response.StatusCode}");
+                throw new RangeNotSupportedException($"服务器未按 Range 返回分段，状态码：{(int)response.StatusCode}");
 
             var range = response.Content.Headers.ContentRange;
             if (range?.Unit != "bytes" || range.From != segment.CurrentOffset || range.To != segment.End ||
                 range.Length != _totalSize)
-                throw new IOException("服务器返回的 Content-Range 与请求分段不一致");
+                throw new RangeNotSupportedException("服务器返回的 Content-Range 与请求分段不一致");
         }
 
         private readonly record struct RateSample(double BytesPerSecond, long UpdatedAt);
     }
 
     private sealed class SlowSegmentException(string message) : IOException(message);
+    private sealed class RangeNotSupportedException(string message) : Exception(message);
 }

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/DownloadResourceManager.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/DownloadResourceManager.cs
@@ -10,10 +10,42 @@ internal static class DownloadResourceManager
     private static readonly AsyncQuota BufferQuota = new();
     private static readonly ConcurrentDictionary<string, AsyncQuota> HostConnectionQuotas = new(StringComparer.OrdinalIgnoreCase);
     private static readonly object BandwidthLock = new();
+    private static readonly object SpeedLock = new();
     private static int _activeConnectionCount;
+    private static long _speedBytes;
+    private static long _speedSnapshotTick = Stopwatch.GetTimestamp();
+    private static long _speed;
     private static long _nextBandwidthTick;
 
     public static int ActiveConnectionCount => Volatile.Read(ref _activeConnectionCount);
+
+    public static long DownloadSpeed
+    {
+        get
+        {
+            lock (SpeedLock)
+            {
+                var now = Stopwatch.GetTimestamp();
+                var elapsedTicks = now - _speedSnapshotTick;
+                if (elapsedTicks >= Stopwatch.Frequency / 4)
+                {
+                    var bytes = Interlocked.Exchange(ref _speedBytes, 0);
+                    _speed = elapsedTicks > 0
+                        ? Math.Max(0L, (long)(bytes * (double)Stopwatch.Frequency / elapsedTicks))
+                        : 0L;
+                    _speedSnapshotTick = now;
+                }
+
+                return _speed;
+            }
+        }
+    }
+
+    internal static void RecordDownloadedBytes(long bytes)
+    {
+        if (bytes > 0)
+            Interlocked.Add(ref _speedBytes, bytes);
+    }
 
     public static async ValueTask<DownloadConnectionLease> AcquireConnectionAsync(string url,
         CancellationToken cancellationToken)

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/DownloadResourceManager.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/DownloadResourceManager.cs
@@ -10,7 +10,10 @@ internal static class DownloadResourceManager
     private static readonly AsyncQuota BufferQuota = new();
     private static readonly ConcurrentDictionary<string, AsyncQuota> HostConnectionQuotas = new(StringComparer.OrdinalIgnoreCase);
     private static readonly object BandwidthLock = new();
+    private static int _activeConnectionCount;
     private static long _nextBandwidthTick;
+
+    public static int ActiveConnectionCount => Volatile.Read(ref _activeConnectionCount);
 
     public static async ValueTask<DownloadConnectionLease> AcquireConnectionAsync(string url,
         CancellationToken cancellationToken)
@@ -24,6 +27,7 @@ internal static class DownloadResourceManager
             var globalLease = await ConnectionQuota.AcquireAsync(1,
                 () => Math.Clamp(ModNet.NetTaskConnectionLimit, 1, ModNet.NetTaskConnectionLimitMax), cancellationToken)
                 .ConfigureAwait(false);
+            Interlocked.Increment(ref _activeConnectionCount);
             return new DownloadConnectionLease(globalLease, hostLease);
         }
         catch
@@ -36,6 +40,11 @@ internal static class DownloadResourceManager
     public static ValueTask<DownloadQuotaLease> ReserveBufferAsync(int bytes, CancellationToken cancellationToken)
     {
         return BufferQuota.AcquireAsync(bytes, () => ModNet.NetTaskBufferBudgetBytes, cancellationToken);
+    }
+
+    internal static void ReleaseConnection()
+    {
+        Interlocked.Decrement(ref _activeConnectionCount);
     }
 
     public static Task ThrottleAsync(int bytes, CancellationToken cancellationToken)
@@ -67,7 +76,12 @@ internal sealed class DownloadConnectionLease(DownloadQuotaLease globalLease, Do
 
     public void Dispose()
     {
-        Interlocked.Exchange(ref _globalLease, null)?.Dispose();
+        var globalLease = Interlocked.Exchange(ref _globalLease, null);
+        if (globalLease is null)
+            return;
+
+        DownloadResourceManager.ReleaseConnection();
+        globalLease.Dispose();
         Interlocked.Exchange(ref _hostLease, null)?.Dispose();
     }
 }

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/DownloadResourceManager.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/DownloadResourceManager.cs
@@ -1,0 +1,145 @@
+using System.Diagnostics;
+using System.Collections.Concurrent;
+
+namespace PCL.Network;
+
+/// <summary>协调所有下载任务共享的连接数、缓冲区和限速额度。</summary>
+internal static class DownloadResourceManager
+{
+    private static readonly AsyncQuota ConnectionQuota = new();
+    private static readonly AsyncQuota BufferQuota = new();
+    private static readonly ConcurrentDictionary<string, AsyncQuota> HostConnectionQuotas = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly object BandwidthLock = new();
+    private static long _nextBandwidthTick;
+
+    public static async ValueTask<DownloadConnectionLease> AcquireConnectionAsync(string url,
+        CancellationToken cancellationToken)
+    {
+        var host = Uri.TryCreate(url, UriKind.Absolute, out var uri) ? uri.Host : url;
+        var hostQuota = HostConnectionQuotas.GetOrAdd(host, static _ => new AsyncQuota());
+        var hostLease = await hostQuota.AcquireAsync(1, () => ModNet.NetTaskConnectionsPerHostLimit, cancellationToken)
+            .ConfigureAwait(false);
+        try
+        {
+            var globalLease = await ConnectionQuota.AcquireAsync(1,
+                () => Math.Clamp(ModNet.NetTaskConnectionLimit, 1, ModNet.NetTaskConnectionLimitMax), cancellationToken)
+                .ConfigureAwait(false);
+            return new DownloadConnectionLease(globalLease, hostLease);
+        }
+        catch
+        {
+            hostLease.Dispose();
+            throw;
+        }
+    }
+
+    public static ValueTask<DownloadQuotaLease> ReserveBufferAsync(int bytes, CancellationToken cancellationToken)
+    {
+        return BufferQuota.AcquireAsync(bytes, () => ModNet.NetTaskBufferBudgetBytes, cancellationToken);
+    }
+
+    public static Task ThrottleAsync(int bytes, CancellationToken cancellationToken)
+    {
+        var limit = ModNet.NetTaskSpeedLimitHigh;
+        if (limit <= 0 || bytes <= 0)
+            return Task.CompletedTask;
+
+        long delayTicks;
+        lock (BandwidthLock)
+        {
+            var now = Stopwatch.GetTimestamp();
+            var availableAt = Math.Max(now, _nextBandwidthTick);
+            var duration = Math.Max(1L, (long)Math.Ceiling((double)bytes * Stopwatch.Frequency / limit));
+            _nextBandwidthTick = availableAt + duration;
+            delayTicks = availableAt - now;
+        }
+
+        return delayTicks <= 0
+            ? Task.CompletedTask
+            : Task.Delay(TimeSpan.FromSeconds((double)delayTicks / Stopwatch.Frequency), cancellationToken);
+    }
+}
+
+internal sealed class DownloadConnectionLease(DownloadQuotaLease globalLease, DownloadQuotaLease hostLease) : IDisposable
+{
+    private DownloadQuotaLease? _globalLease = globalLease;
+    private DownloadQuotaLease? _hostLease = hostLease;
+
+    public void Dispose()
+    {
+        Interlocked.Exchange(ref _globalLease, null)?.Dispose();
+        Interlocked.Exchange(ref _hostLease, null)?.Dispose();
+    }
+}
+
+internal sealed class DownloadQuotaLease : IDisposable
+{
+    private AsyncQuota? _quota;
+    private readonly long _amount;
+
+    internal DownloadQuotaLease(AsyncQuota quota, long amount)
+    {
+        _quota = quota;
+        _amount = amount;
+    }
+
+    public void Dispose()
+    {
+        Interlocked.Exchange(ref _quota, null)?.Release(_amount);
+    }
+}
+
+internal sealed class AsyncQuota
+{
+    private readonly object _lock = new();
+    private readonly List<TaskCompletionSource> _waiters = new();
+    private long _used;
+
+    public async ValueTask<DownloadQuotaLease> AcquireAsync(long amount, Func<long> getCapacity,
+        CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(amount);
+
+        while (true)
+        {
+            TaskCompletionSource? waiter = null;
+            lock (_lock)
+            {
+                var capacity = Math.Max(amount, getCapacity());
+                if (_used + amount <= capacity)
+                {
+                    _used += amount;
+                    return new DownloadQuotaLease(this, amount);
+                }
+
+                waiter = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                _waiters.Add(waiter);
+            }
+
+            try
+            {
+                await waiter.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                lock (_lock)
+                    _waiters.Remove(waiter);
+                throw;
+            }
+        }
+    }
+
+    public void Release(long amount)
+    {
+        TaskCompletionSource[] waiters;
+        lock (_lock)
+        {
+            _used = Math.Max(0, _used - amount);
+            waiters = _waiters.ToArray();
+            _waiters.Clear();
+        }
+
+        foreach (var waiter in waiters)
+            waiter.TrySetResult();
+    }
+}

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/DownloadResourceManager.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/DownloadResourceManager.cs
@@ -131,15 +131,17 @@ internal sealed class AsyncQuota
 
     public void Release(long amount)
     {
-        TaskCompletionSource[] waiters;
+        TaskCompletionSource? waiter = null;
         lock (_lock)
         {
             _used = Math.Max(0, _used - amount);
-            waiters = _waiters.ToArray();
-            _waiters.Clear();
+            if (_waiters.Count > 0)
+            {
+                waiter = _waiters[0];
+                _waiters.RemoveAt(0);
+            }
         }
 
-        foreach (var waiter in waiters)
-            waiter.TrySetResult();
+        waiter?.TrySetResult();
     }
 }

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/DownloadResourceManager.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/DownloadResourceManager.cs
@@ -8,14 +8,15 @@ internal static class DownloadResourceManager
 {
     private static readonly AsyncQuota ConnectionQuota = new();
     private static readonly AsyncQuota BufferQuota = new();
-    private static readonly ConcurrentDictionary<string, AsyncQuota> HostConnectionQuotas = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly ConcurrentDictionary<string, HostQuotaEntry> HostConnectionQuotas = new(StringComparer.OrdinalIgnoreCase);
     private static readonly object BandwidthLock = new();
     private static readonly object SpeedLock = new();
     private static int _activeConnectionCount;
     private static long _speedBytes;
     private static long _speedSnapshotTick = Stopwatch.GetTimestamp();
     private static long _speed;
-    private static long _nextBandwidthTick;
+    private static readonly LinkedList<BandwidthReservation> BandwidthReservations = new();
+    private static bool _bandwidthPumpRunning;
 
     public static int ActiveConnectionCount => Volatile.Read(ref _activeConnectionCount);
 
@@ -51,20 +52,23 @@ internal static class DownloadResourceManager
         CancellationToken cancellationToken)
     {
         var host = Uri.TryCreate(url, UriKind.Absolute, out var uri) ? uri.Host : url;
-        var hostQuota = HostConnectionQuotas.GetOrAdd(host, static _ => new AsyncQuota());
-        var hostLease = await hostQuota.AcquireAsync(1, () => ModNet.NetTaskConnectionsPerHostLimit, cancellationToken)
-            .ConfigureAwait(false);
+        var hostEntry = AcquireHostQuotaEntry(host);
+        DownloadQuotaLease? hostLease = null;
         try
         {
+            hostLease = await hostEntry.Quota.AcquireAsync(1, () => ModNet.NetTaskConnectionsPerHostLimit,
+                cancellationToken)
+            .ConfigureAwait(false);
             var globalLease = await ConnectionQuota.AcquireAsync(1,
                 () => Math.Clamp(ModNet.NetTaskConnectionLimit, 1, ModNet.NetTaskConnectionLimitMax), cancellationToken)
                 .ConfigureAwait(false);
             Interlocked.Increment(ref _activeConnectionCount);
-            return new DownloadConnectionLease(globalLease, hostLease);
+            return new DownloadConnectionLease(globalLease, hostLease, hostEntry);
         }
         catch
         {
-            hostLease.Dispose();
+            hostLease?.Dispose();
+            ReleaseHostQuotaEntry(hostEntry);
             throw;
         }
     }
@@ -79,32 +83,108 @@ internal static class DownloadResourceManager
         Interlocked.Decrement(ref _activeConnectionCount);
     }
 
-    public static Task ThrottleAsync(int bytes, CancellationToken cancellationToken)
+    public static async Task ThrottleAsync(int bytes, CancellationToken cancellationToken)
     {
         var limit = ModNet.NetTaskSpeedLimitHigh;
         if (limit <= 0 || bytes <= 0)
-            return Task.CompletedTask;
+            return;
 
-        long delayTicks;
+        var reservation = new BandwidthReservation(Math.Max(1L,
+            (long)Math.Ceiling((double)bytes * Stopwatch.Frequency / limit)));
         lock (BandwidthLock)
         {
-            var now = Stopwatch.GetTimestamp();
-            var availableAt = Math.Max(now, _nextBandwidthTick);
-            var duration = Math.Max(1L, (long)Math.Ceiling((double)bytes * Stopwatch.Frequency / limit));
-            _nextBandwidthTick = availableAt + duration;
-            delayTicks = availableAt - now;
+            reservation.Node = BandwidthReservations.AddLast(reservation);
+            if (!_bandwidthPumpRunning)
+            {
+                _bandwidthPumpRunning = true;
+                _ = PumpBandwidthReservationsAsync();
+            }
         }
 
-        return delayTicks <= 0
-            ? Task.CompletedTask
-            : Task.Delay(TimeSpan.FromSeconds((double)delayTicks / Stopwatch.Frequency), cancellationToken);
+        try
+        {
+            await reservation.Completion.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            lock (BandwidthLock)
+            {
+                if (reservation.Node?.List is not null)
+                    BandwidthReservations.Remove(reservation.Node);
+            }
+
+            throw;
+        }
+    }
+
+    private static async Task PumpBandwidthReservationsAsync()
+    {
+        while (true)
+        {
+            BandwidthReservation? reservation;
+            lock (BandwidthLock)
+            {
+                if (BandwidthReservations.First is null)
+                {
+                    _bandwidthPumpRunning = false;
+                    return;
+                }
+
+                reservation = BandwidthReservations.First.Value;
+                BandwidthReservations.RemoveFirst();
+                reservation.Node = null;
+            }
+
+            reservation.Completion.TrySetResult();
+            await Task.Delay(TimeSpan.FromSeconds((double)reservation.DurationTicks / Stopwatch.Frequency))
+                .ConfigureAwait(false);
+        }
+    }
+
+    private static HostQuotaEntry AcquireHostQuotaEntry(string host)
+    {
+        while (true)
+        {
+            var entry = HostConnectionQuotas.GetOrAdd(host, static key => new HostQuotaEntry(key));
+            var referenceAdded = entry.TryAddReference();
+            if (referenceAdded)
+            {
+                if (HostConnectionQuotas.TryGetValue(host, out var current) && ReferenceEquals(entry, current))
+                    return entry;
+
+                ReleaseHostQuotaEntry(entry);
+                continue;
+            }
+
+            if (HostConnectionQuotas.TryGetValue(host, out var retiredEntry) && ReferenceEquals(entry, retiredEntry))
+                ((ICollection<KeyValuePair<string, HostQuotaEntry>>)HostConnectionQuotas)
+                    .Remove(new KeyValuePair<string, HostQuotaEntry>(host, entry));
+        }
+    }
+
+    internal static void ReleaseHostQuotaEntry(HostQuotaEntry entry)
+    {
+        if (!entry.ReleaseReference())
+            return;
+
+        ((ICollection<KeyValuePair<string, HostQuotaEntry>>)HostConnectionQuotas)
+            .Remove(new KeyValuePair<string, HostQuotaEntry>(entry.Host, entry));
+    }
+
+    private sealed class BandwidthReservation(long durationTicks)
+    {
+        public long DurationTicks { get; } = durationTicks;
+        public TaskCompletionSource Completion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public LinkedListNode<BandwidthReservation>? Node { get; set; }
     }
 }
 
-internal sealed class DownloadConnectionLease(DownloadQuotaLease globalLease, DownloadQuotaLease hostLease) : IDisposable
+internal sealed class DownloadConnectionLease(DownloadQuotaLease globalLease, DownloadQuotaLease hostLease,
+    HostQuotaEntry hostEntry) : IDisposable
 {
     private DownloadQuotaLease? _globalLease = globalLease;
     private DownloadQuotaLease? _hostLease = hostLease;
+    private HostQuotaEntry? _hostEntry = hostEntry;
 
     public void Dispose()
     {
@@ -115,6 +195,9 @@ internal sealed class DownloadConnectionLease(DownloadQuotaLease globalLease, Do
         DownloadResourceManager.ReleaseConnection();
         globalLease.Dispose();
         Interlocked.Exchange(ref _hostLease, null)?.Dispose();
+        var hostEntry = Interlocked.Exchange(ref _hostEntry, null);
+        if (hostEntry is not null)
+            DownloadResourceManager.ReleaseHostQuotaEntry(hostEntry);
     }
 }
 
@@ -177,17 +260,49 @@ internal sealed class AsyncQuota
 
     public void Release(long amount)
     {
-        TaskCompletionSource? waiter = null;
+        TaskCompletionSource[] waiters;
         lock (_lock)
         {
             _used = Math.Max(0, _used - amount);
-            if (_waiters.Count > 0)
-            {
-                waiter = _waiters[0];
-                _waiters.RemoveAt(0);
-            }
+            waiters = _waiters.ToArray();
+            _waiters.Clear();
         }
 
-        waiter?.TrySetResult();
+        foreach (var waiter in waiters)
+            waiter.TrySetResult();
+    }
+}
+
+internal sealed class HostQuotaEntry(string host)
+{
+    private readonly object _lock = new();
+    private int _referenceCount;
+    private bool _retired;
+
+    public string Host { get; } = host;
+    public AsyncQuota Quota { get; } = new();
+
+    public bool TryAddReference()
+    {
+        lock (_lock)
+        {
+            if (_retired)
+                return false;
+
+            _referenceCount++;
+            return true;
+        }
+    }
+
+    public bool ReleaseReference()
+    {
+        lock (_lock)
+        {
+            if (--_referenceCount != 0)
+                return false;
+
+            _retired = true;
+            return true;
+        }
     }
 }

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
@@ -14,9 +14,6 @@ public static class FileDownloader
 {
     private const int RequestTimeoutMilliseconds = 30_000;
     private const int MaxDownloadRetries = 3;
-    private const int SequentialSlowCheckSeconds = 5;
-    private const long SequentialSlowRestartMinimumSize = 50L * 1024;
-    private const long SequentialSlowSpeedBytesPerSecond = 40L * 1024;
 
     public static async Task DownloadAsync(string url, string localPath, bool useBrowserUserAgent = false,
         string customUserAgent = "", CancellationToken cancellationToken = default,
@@ -64,7 +61,7 @@ public static class FileDownloader
                 try
                 {
                     await DownloadSingleAsync(url, localPath, useBrowserUserAgent, customUserAgent, cancellationToken,
-                        enableParallelChunks, trackedFile, retry == MaxDownloadRetries).ConfigureAwait(false);
+                        enableParallelChunks, trackedFile).ConfigureAwait(false);
                     return;
                 }
                 catch (OperationCanceledException)
@@ -92,13 +89,13 @@ public static class FileDownloader
     }
 
     private static async Task DownloadSingleAsync(string url, string localPath, bool useBrowserUserAgent,
-        string customUserAgent, CancellationToken cancellationToken, bool enableParallelChunks, DownloadFile? trackedFile,
-        bool isFinalRetryRound)
+        string customUserAgent, CancellationToken cancellationToken, bool enableParallelChunks, DownloadFile? trackedFile)
     {
         ModBase.Log($"[Download] 开始下载：{url} -> {localPath}");
         CleanupTempFiles(localPath);
 
-        var expectedSize = trackedFile?.Check?.actualSize ?? -1;
+        var checker = trackedFile?.Check;
+        var expectedSize = string.IsNullOrEmpty(checker?.hash) ? checker?.actualSize ?? -1 : -1;
         var sequentialRequestKind = (expectedSize >= 0 && expectedSize < AdaptiveRangeDownloader.SmallFileThreshold) ||
                                      (expectedSize < 0 && !enableParallelChunks)
             ? DownloadRequestKind.SmallOrBatch
@@ -108,6 +105,7 @@ public static class FileDownloader
                 useBrowserUserAgent, customUserAgent, cancellationToken, trackedFile,
                 expectedSize).ConfigureAwait(false))
         {
+            await ValidateTempFileAsync(localPath, checker, cancellationToken).ConfigureAwait(false);
             PromoteTempFile(localPath);
             if (!File.Exists(localPath))
                 throw new IOException($"分段下载未产生任何文件：{localPath}");
@@ -117,12 +115,12 @@ public static class FileDownloader
         }
 
         await DownloadSequentiallyAsync(url, localPath, useBrowserUserAgent, customUserAgent, cancellationToken,
-            trackedFile, sequentialRequestKind, isFinalRetryRound).ConfigureAwait(false);
+            trackedFile, sequentialRequestKind).ConfigureAwait(false);
     }
 
     private static async Task DownloadSequentiallyAsync(string url, string localPath, bool useBrowserUserAgent,
         string customUserAgent, CancellationToken cancellationToken, DownloadFile? trackedFile,
-        DownloadRequestKind requestKind, bool isFinalRetryRound)
+        DownloadRequestKind requestKind)
     {
         const int bufferSize = 64 * 1024;
         const int readTimeoutMilliseconds = 30_000;
@@ -134,8 +132,10 @@ public static class FileDownloader
             throw new HttpRequestException($"下载请求失败：{(int)response.StatusCode} {response.ReasonPhrase}");
 
         var responseContentLength = response.Content.Headers.ContentLength ?? -1;
-        var manifestExpectedSize = trackedFile?.Check?.actualSize ?? -1;
-        if (responseContentLength >= 0 && manifestExpectedSize >= 0 && responseContentLength != manifestExpectedSize)
+        var checker = trackedFile?.Check;
+        var manifestExpectedSize = checker?.actualSize ?? -1;
+        if (string.IsNullOrEmpty(checker?.hash) && responseContentLength >= 0 && manifestExpectedSize >= 0 &&
+            responseContentLength != manifestExpectedSize)
             throw new IOException($"下载大小与清单不一致：响应为 {responseContentLength}，清单为 {manifestExpectedSize}");
 
         var totalSize = responseContentLength >= 0 ? responseContentLength : manifestExpectedSize;
@@ -159,10 +159,6 @@ public static class FileDownloader
         using var bufferLease = await DownloadResourceManager.ReserveBufferAsync(bufferSize, cancellationToken)
             .ConfigureAwait(false);
         var buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
-        var slowCheckEnabled = !isFinalRetryRound && totalSize > SequentialSlowRestartMinimumSize &&
-                               ModNet.NetTaskSpeedLimitHigh <= 0;
-        var slowCheckBytes = 0L;
-        var slowCheckTick = Stopwatch.GetTimestamp();
         try
         {
             while (true)
@@ -188,22 +184,6 @@ public static class FileDownloader
                 DownloadResourceManager.RecordDownloadedBytes(read);
                 downloaded += read;
                 UpdateSequentialProgress(trackedFile, downloaded, totalSize, ref lastProgressBytes, ref lastProgressTick);
-
-                if (slowCheckEnabled && downloaded < totalSize)
-                {
-                    var now = Stopwatch.GetTimestamp();
-                    var elapsed = (double)(now - slowCheckTick) / Stopwatch.Frequency;
-                    if (elapsed >= SequentialSlowCheckSeconds)
-                    {
-                        var speed = (downloaded - slowCheckBytes) / Math.Max(0.001, elapsed);
-                        if (speed < SequentialSlowSpeedBytesPerSecond)
-                            throw new SlowSequentialDownloadException(
-                                $"顺序下载速度连续 {SequentialSlowCheckSeconds} 秒低于 {SequentialSlowSpeedBytesPerSecond / 1024} KiB/s");
-
-                        slowCheckBytes = downloaded;
-                        slowCheckTick = now;
-                    }
-                }
             }
         }
         finally
@@ -215,8 +195,8 @@ public static class FileDownloader
         await output.DisposeAsync().ConfigureAwait(false);
         if (responseContentLength >= 0 && downloaded != responseContentLength)
             throw new IOException($"下载不完整：已写入 {downloaded}，应为响应声明的 {responseContentLength}");
-        if (manifestExpectedSize >= 0 && downloaded != manifestExpectedSize)
-            throw new IOException($"下载不完整：已写入 {downloaded}，应为清单声明的 {manifestExpectedSize}");
+
+        await ValidateTempFileAsync(localPath, checker, cancellationToken).ConfigureAwait(false);
 
         if (trackedFile is not null && totalSize <= 0)
         {
@@ -230,6 +210,20 @@ public static class FileDownloader
             throw new IOException($"下载未产生任何文件：{localPath}");
         MarkDownloadCompleted(trackedFile);
         ModBase.Log($"[Download] 顺序下载成功：{localPath}");
+    }
+
+    private static async Task ValidateTempFileAsync(string localPath, ModBase.FileChecker? checker,
+        CancellationToken cancellationToken)
+    {
+        if (checker is null)
+            return;
+
+        var tempPath = localPath + ModNet.NetDownloadEnd;
+        var checkResult = string.IsNullOrEmpty(checker.hash)
+            ? checker.Check(tempPath)
+            : await Task.Run(() => checker.Check(tempPath), cancellationToken).ConfigureAwait(false);
+        if (checkResult is not null)
+            throw new IOException($"下载文件校验失败：{checkResult}");
     }
 
     private static void UpdateSequentialProgress(DownloadFile? trackedFile, long downloaded, long totalSize,
@@ -362,8 +356,6 @@ public static class FileDownloader
             }
         }
     }
-
-    private sealed class SlowSequentialDownloadException(string message) : IOException(message);
 
     internal static HttpClient GetHttpClient(string url)
     {

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
@@ -5,12 +5,16 @@ using System.Net;
 using System.Net.Http;
 using PCL.Core.App;
 using PCL.Core.IO.Net;
+using PCL.Core.Utils;
 
 
 namespace PCL.Network;
 
 public static class FileDownloader
 {
+    private const int RequestTimeoutMilliseconds = 30_000;
+    private const int MaxDownloadRetries = 3;
+
     public static async Task DownloadAsync(string url, string localPath, bool useBrowserUserAgent = false,
         string customUserAgent = "", CancellationToken cancellationToken = default,
         bool enableParallelChunks = true, DownloadFile? trackedFile = null)
@@ -50,25 +54,35 @@ public static class FileDownloader
         Directory.CreateDirectory(Path.GetDirectoryName(localPath) ?? throw new ArgumentException("下载路径无效", nameof(localPath)));
 
         Exception? lastException = null;
-        foreach (var url in urlList)
+        for (var retry = 0; retry <= MaxDownloadRetries; retry++)
         {
-            try
+            foreach (var url in urlList)
             {
-                await DownloadSingleAsync(url, localPath, useBrowserUserAgent, customUserAgent, cancellationToken,
-                    enableParallelChunks, trackedFile).ConfigureAwait(false);
-                return;
+                try
+                {
+                    await DownloadSingleAsync(url, localPath, useBrowserUserAgent, customUserAgent, cancellationToken,
+                        enableParallelChunks, trackedFile).ConfigureAwait(false);
+                    return;
+                }
+                catch (OperationCanceledException)
+                {
+                    CleanupTempFiles(localPath);
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    lastException = ex;
+                    CleanupTempFiles(localPath);
+                    ModBase.Log(ex, $"[Download] 下载源失败：{url}", ModBase.LogLevel.Debug);
+                }
             }
-            catch (OperationCanceledException)
-            {
-                CleanupTempFiles(localPath);
-                throw;
-            }
-            catch (Exception ex)
-            {
-                lastException = ex;
-                CleanupTempFiles(localPath);
-                ModBase.Log(ex, $"[Download] 下载失败，尝试下一个源：{url}", ModBase.LogLevel.Debug);
-            }
+
+            if (retry >= MaxDownloadRetries)
+                break;
+
+            ModBase.Log(lastException, $"[Download] 重试 {retry + 1}/{MaxDownloadRetries}：{localPath}",
+                ModBase.LogLevel.Debug);
+            await Task.Delay(RandomUtils.NextInt(300, 500 + retry * 300), cancellationToken).ConfigureAwait(false);
         }
 
         throw new IOException($"下载失败：{localPath}", lastException);
@@ -111,8 +125,7 @@ public static class FileDownloader
         using var connection = await DownloadResourceManager.AcquireConnectionAsync(url, cancellationToken)
             .ConfigureAwait(false);
         using var request = CreateDownloadRequest(url, useBrowserUserAgent, customUserAgent, requestKind);
-        using var response = await GetHttpClient(url)
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        using var response = await SendDownloadRequestAsync(url, request, cancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
             throw new HttpRequestException($"下载请求失败：{(int)response.StatusCode} {response.ReasonPhrase}");
 
@@ -213,6 +226,24 @@ public static class FileDownloader
         RequestSigning.SecretHeadersSign(url, ref request, useBrowserUserAgent, customUserAgent);
         ApplyHttpVersion(request, requestKind);
         return request;
+    }
+
+    internal static async Task<HttpResponseMessage> SendDownloadRequestAsync(string url,
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        using var requestTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        requestTimeout.CancelAfter(RequestTimeoutMilliseconds);
+        try
+        {
+            return await GetHttpClient(url)
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, requestTimeout.Token)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested &&
+                                                    requestTimeout.IsCancellationRequested)
+        {
+            throw new TimeoutException($"等待下载源响应超时（30 秒）：{url}", ex);
+        }
     }
 
     private static void ApplyHttpVersion(HttpRequestMessage request, DownloadRequestKind requestKind)

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
@@ -64,7 +64,7 @@ public static class FileDownloader
                 try
                 {
                     await DownloadSingleAsync(url, localPath, useBrowserUserAgent, customUserAgent, cancellationToken,
-                        enableParallelChunks, trackedFile).ConfigureAwait(false);
+                        enableParallelChunks, trackedFile, retry == MaxDownloadRetries).ConfigureAwait(false);
                     return;
                 }
                 catch (OperationCanceledException)
@@ -92,7 +92,8 @@ public static class FileDownloader
     }
 
     private static async Task DownloadSingleAsync(string url, string localPath, bool useBrowserUserAgent,
-        string customUserAgent, CancellationToken cancellationToken, bool enableParallelChunks, DownloadFile? trackedFile)
+        string customUserAgent, CancellationToken cancellationToken, bool enableParallelChunks, DownloadFile? trackedFile,
+        bool isFinalRetryRound)
     {
         ModBase.Log($"[Download] 开始下载：{url} -> {localPath}");
         CleanupTempFiles(localPath);
@@ -116,12 +117,12 @@ public static class FileDownloader
         }
 
         await DownloadSequentiallyAsync(url, localPath, useBrowserUserAgent, customUserAgent, cancellationToken,
-            trackedFile, sequentialRequestKind).ConfigureAwait(false);
+            trackedFile, sequentialRequestKind, isFinalRetryRound).ConfigureAwait(false);
     }
 
     private static async Task DownloadSequentiallyAsync(string url, string localPath, bool useBrowserUserAgent,
         string customUserAgent, CancellationToken cancellationToken, DownloadFile? trackedFile,
-        DownloadRequestKind requestKind)
+        DownloadRequestKind requestKind, bool isFinalRetryRound)
     {
         const int bufferSize = 64 * 1024;
         const int readTimeoutMilliseconds = 30_000;
@@ -132,10 +133,12 @@ public static class FileDownloader
         if (!response.IsSuccessStatusCode)
             throw new HttpRequestException($"下载请求失败：{(int)response.StatusCode} {response.ReasonPhrase}");
 
-        var totalSize = response.Content.Headers.ContentLength ?? -1;
-        // 某些源使用 chunked 传输没有 Content-Length，但清单校验信息仍可能带有文件大小
-        // 这个大小只用于慢速判断，完整性仍按响应头的 totalSize 校验
-        var slowCheckSize = totalSize > 0 ? totalSize : trackedFile?.Check?.actualSize ?? -1;
+        var responseContentLength = response.Content.Headers.ContentLength ?? -1;
+        var manifestExpectedSize = trackedFile?.Check?.actualSize ?? -1;
+        if (responseContentLength >= 0 && manifestExpectedSize >= 0 && responseContentLength != manifestExpectedSize)
+            throw new IOException($"下载大小与清单不一致：响应为 {responseContentLength}，清单为 {manifestExpectedSize}");
+
+        var totalSize = responseContentLength >= 0 ? responseContentLength : manifestExpectedSize;
         if (trackedFile is not null)
         {
             trackedFile.State = PCL.Network.NetState.Downloading;
@@ -156,7 +159,8 @@ public static class FileDownloader
         using var bufferLease = await DownloadResourceManager.ReserveBufferAsync(bufferSize, cancellationToken)
             .ConfigureAwait(false);
         var buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
-        var slowCheckEnabled = slowCheckSize > SequentialSlowRestartMinimumSize && ModNet.NetTaskSpeedLimitHigh <= 0;
+        var slowCheckEnabled = !isFinalRetryRound && totalSize > SequentialSlowRestartMinimumSize &&
+                               ModNet.NetTaskSpeedLimitHigh <= 0;
         var slowCheckBytes = 0L;
         var slowCheckTick = Stopwatch.GetTimestamp();
         try
@@ -185,7 +189,7 @@ public static class FileDownloader
                 downloaded += read;
                 UpdateSequentialProgress(trackedFile, downloaded, totalSize, ref lastProgressBytes, ref lastProgressTick);
 
-                if (slowCheckEnabled && downloaded < slowCheckSize)
+                if (slowCheckEnabled && downloaded < totalSize)
                 {
                     var now = Stopwatch.GetTimestamp();
                     var elapsed = (double)(now - slowCheckTick) / Stopwatch.Frequency;
@@ -209,8 +213,10 @@ public static class FileDownloader
 
         connection.Dispose();
         await output.DisposeAsync().ConfigureAwait(false);
-        if (totalSize >= 0 && downloaded != totalSize)
-            throw new IOException($"下载不完整：已写入 {downloaded}，应为 {totalSize}");
+        if (responseContentLength >= 0 && downloaded != responseContentLength)
+            throw new IOException($"下载不完整：已写入 {downloaded}，应为响应声明的 {responseContentLength}");
+        if (manifestExpectedSize >= 0 && downloaded != manifestExpectedSize)
+            throw new IOException($"下载不完整：已写入 {downloaded}，应为清单声明的 {manifestExpectedSize}");
 
         if (trackedFile is not null && totalSize <= 0)
         {
@@ -267,7 +273,7 @@ public static class FileDownloader
         catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested &&
                                                     requestTimeout.IsCancellationRequested)
         {
-            throw new TimeoutException($"等待下载源响应超时（30 秒）：{url}", ex);
+            throw new DownloadRequestTimeoutException($"等待下载源响应超时（30 秒）：{url}", ex);
         }
     }
 
@@ -370,6 +376,9 @@ public static class FileDownloader
         return NetworkService.GetClient();
     }
 }
+
+internal sealed class DownloadRequestTimeoutException(string message, Exception innerException)
+    : TimeoutException(message, innerException);
 
 internal enum DownloadRequestKind
 {

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Diagnostics;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using PCL.Core.IO.Net;
 
@@ -202,6 +203,8 @@ public static class FileDownloader
     {
         var request = new HttpRequestMessage(HttpMethod.Get, url);
         RequestSigning.SecretHeadersSign(url, ref request, useBrowserUserAgent, customUserAgent);
+        request.Version = HttpVersion.Version11;
+        request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
         return request;
     }
 

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
@@ -1,7 +1,6 @@
 using System.Buffers;
 using System.Diagnostics;
 using System.IO;
-using System.Net.Http.Headers;
 using System.Net.Http;
 using PCL.Core.IO.Net;
 
@@ -103,8 +102,6 @@ public static class FileDownloader
         using var connection = await DownloadResourceManager.AcquireConnectionAsync(url, cancellationToken)
             .ConfigureAwait(false);
         using var request = CreateDownloadRequest(url, useBrowserUserAgent, customUserAgent);
-        request.Headers.AcceptEncoding.Clear();
-        request.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("identity"));
         using var response = await GetHttpClient(url)
             .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
@@ -125,6 +122,7 @@ public static class FileDownloader
         long lastProgressBytes = 0;
         var lastProgressTick = Stopwatch.GetTimestamp();
         await using var input = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        using var readTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         await using var output = new FileStream(localPath + ModNet.NetDownloadEnd, FileMode.Create, FileAccess.Write,
             FileShare.Read, bufferSize: 1, FileOptions.Asynchronous | FileOptions.SequentialScan);
         while (true)
@@ -135,19 +133,16 @@ public static class FileDownloader
             try
             {
                 int read;
-                using (var readTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+                readTimeout.CancelAfter(readTimeoutMilliseconds);
+                try
                 {
-                    readTimeout.CancelAfter(readTimeoutMilliseconds);
-                    try
-                    {
-                        read = await input.ReadAsync(buffer.AsMemory(0, bufferSize), readTimeout.Token)
-                            .ConfigureAwait(false);
-                    }
-                    catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested &&
-                                                           readTimeout.IsCancellationRequested)
-                    {
-                        throw new TimeoutException($"下载超时（{url}）");
-                    }
+                    read = await input.ReadAsync(buffer.AsMemory(0, bufferSize), readTimeout.Token)
+                        .ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested &&
+                                                       readTimeout.IsCancellationRequested)
+                {
+                    throw new TimeoutException($"下载超时（{url}）");
                 }
 
                 if (read == 0)

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
@@ -99,7 +99,7 @@ public static class FileDownloader
         string customUserAgent, CancellationToken cancellationToken, DownloadFile? trackedFile)
     {
         const int bufferSize = 64 * 1024;
-        const int readTimeoutMilliseconds = 60_000;
+        const int readTimeoutMilliseconds = 30_000;
         using var connection = await DownloadResourceManager.AcquireConnectionAsync(url, cancellationToken)
             .ConfigureAwait(false);
         using var request = CreateDownloadRequest(url, useBrowserUserAgent, customUserAgent);

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
@@ -14,6 +14,9 @@ public static class FileDownloader
 {
     private const int RequestTimeoutMilliseconds = 30_000;
     private const int MaxDownloadRetries = 3;
+    private const int SequentialSlowCheckSeconds = 3;
+    private const long SequentialSlowRestartMinimumSize = 50L * 1024;
+    private const long SlowSpeedBytesPerSecond = 50L * 1024;
 
     public static async Task DownloadAsync(string url, string localPath, bool useBrowserUserAgent = false,
         string customUserAgent = "", CancellationToken cancellationToken = default,
@@ -130,6 +133,9 @@ public static class FileDownloader
             throw new HttpRequestException($"下载请求失败：{(int)response.StatusCode} {response.ReasonPhrase}");
 
         var totalSize = response.Content.Headers.ContentLength ?? -1;
+        // 某些源使用 chunked 传输没有 Content-Length，但清单校验信息仍可能带有文件大小
+        // 这个大小只用于慢速判断，完整性仍按响应头的 totalSize 校验
+        var slowCheckSize = totalSize > 0 ? totalSize : trackedFile?.Check?.actualSize ?? -1;
         if (trackedFile is not null)
         {
             trackedFile.State = PCL.Network.NetState.Downloading;
@@ -150,6 +156,9 @@ public static class FileDownloader
         using var bufferLease = await DownloadResourceManager.ReserveBufferAsync(bufferSize, cancellationToken)
             .ConfigureAwait(false);
         var buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+        var slowCheckEnabled = slowCheckSize > SequentialSlowRestartMinimumSize && ModNet.NetTaskSpeedLimitHigh <= 0;
+        var slowCheckBytes = 0L;
+        var slowCheckTick = Stopwatch.GetTimestamp();
         try
         {
             while (true)
@@ -175,6 +184,21 @@ public static class FileDownloader
                 DownloadResourceManager.RecordDownloadedBytes(read);
                 downloaded += read;
                 UpdateSequentialProgress(trackedFile, downloaded, totalSize, ref lastProgressBytes, ref lastProgressTick);
+
+                if (slowCheckEnabled && downloaded < slowCheckSize)
+                {
+                    var now = Stopwatch.GetTimestamp();
+                    var elapsed = (double)(now - slowCheckTick) / Stopwatch.Frequency;
+                    if (elapsed >= SequentialSlowCheckSeconds)
+                    {
+                        var speed = (downloaded - slowCheckBytes) / Math.Max(0.001, elapsed);
+                        if (speed < SlowSpeedBytesPerSecond)
+                            throw new SlowSequentialDownloadException($"顺序下载速度低于 {SlowSpeedBytesPerSecond / 1024} KiB/s");
+
+                        slowCheckBytes = downloaded;
+                        slowCheckTick = now;
+                    }
+                }
             }
         }
         finally
@@ -331,6 +355,8 @@ public static class FileDownloader
             }
         }
     }
+
+    private sealed class SlowSequentialDownloadException(string message) : IOException(message);
 
     internal static HttpClient GetHttpClient(string url)
     {

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
@@ -159,6 +159,7 @@ public static class FileDownloader
             }
         }
 
+        connection.Dispose();
         await output.FlushAsync(cancellationToken).ConfigureAwait(false);
         await output.DisposeAsync().ConfigureAwait(false);
         if (totalSize >= 0 && downloaded != totalSize)

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
@@ -124,13 +124,13 @@ public static class FileDownloader
         await using var input = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
         using var readTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         await using var output = new FileStream(localPath + ModNet.NetDownloadEnd, FileMode.Create, FileAccess.Write,
-            FileShare.Read, bufferSize: 1, FileOptions.Asynchronous | FileOptions.SequentialScan);
-        while (true)
+            FileShare.Read, bufferSize: bufferSize, FileOptions.Asynchronous | FileOptions.SequentialScan);
+        using var bufferLease = await DownloadResourceManager.ReserveBufferAsync(bufferSize, cancellationToken)
+            .ConfigureAwait(false);
+        var buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+        try
         {
-            using var bufferLease = await DownloadResourceManager.ReserveBufferAsync(bufferSize, cancellationToken)
-                .ConfigureAwait(false);
-            var buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
-            try
+            while (true)
             {
                 int read;
                 readTimeout.CancelAfter(readTimeoutMilliseconds);
@@ -153,14 +153,13 @@ public static class FileDownloader
                 downloaded += read;
                 UpdateSequentialProgress(trackedFile, downloaded, totalSize, ref lastProgressBytes, ref lastProgressTick);
             }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(buffer);
-            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
         }
 
         connection.Dispose();
-        await output.FlushAsync(cancellationToken).ConfigureAwait(false);
         await output.DisposeAsync().ConfigureAwait(false);
         if (totalSize >= 0 && downloaded != totalSize)
             throw new IOException($"下载不完整：已写入 {downloaded}，应为 {totalSize}");

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
@@ -150,6 +150,7 @@ public static class FileDownloader
 
                 await DownloadResourceManager.ThrottleAsync(read, cancellationToken).ConfigureAwait(false);
                 await output.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+                DownloadResourceManager.RecordDownloadedBytes(read);
                 downloaded += read;
                 UpdateSequentialProgress(trackedFile, downloaded, totalSize, ref lastProgressBytes, ref lastProgressTick);
             }

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
@@ -14,9 +14,9 @@ public static class FileDownloader
 {
     private const int RequestTimeoutMilliseconds = 30_000;
     private const int MaxDownloadRetries = 3;
-    private const int SequentialSlowCheckSeconds = 3;
+    private const int SequentialSlowCheckSeconds = 5;
     private const long SequentialSlowRestartMinimumSize = 50L * 1024;
-    private const long SlowSpeedBytesPerSecond = 50L * 1024;
+    private const long SequentialSlowSpeedBytesPerSecond = 40L * 1024;
 
     public static async Task DownloadAsync(string url, string localPath, bool useBrowserUserAgent = false,
         string customUserAgent = "", CancellationToken cancellationToken = default,
@@ -192,8 +192,9 @@ public static class FileDownloader
                     if (elapsed >= SequentialSlowCheckSeconds)
                     {
                         var speed = (downloaded - slowCheckBytes) / Math.Max(0.001, elapsed);
-                        if (speed < SlowSpeedBytesPerSecond)
-                            throw new SlowSequentialDownloadException($"顺序下载速度低于 {SlowSpeedBytesPerSecond / 1024} KiB/s");
+                        if (speed < SequentialSlowSpeedBytesPerSecond)
+                            throw new SlowSequentialDownloadException(
+                                $"顺序下载速度连续 {SequentialSlowCheckSeconds} 秒低于 {SequentialSlowSpeedBytesPerSecond / 1024} KiB/s");
 
                         slowCheckBytes = downloaded;
                         slowCheckTick = now;

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
@@ -80,7 +80,8 @@ public static class FileDownloader
         CleanupTempFiles(localPath);
 
         if (enableParallelChunks && await AdaptiveRangeDownloader.TryDownloadAsync(url, localPath,
-                useBrowserUserAgent, customUserAgent, cancellationToken, trackedFile).ConfigureAwait(false))
+                useBrowserUserAgent, customUserAgent, cancellationToken, trackedFile,
+                trackedFile?.Check?.actualSize ?? -1).ConfigureAwait(false))
         {
             PromoteTempFile(localPath);
             if (!File.Exists(localPath))

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using PCL.Core.App;
 using PCL.Core.IO.Net;
 
 
@@ -79,9 +80,15 @@ public static class FileDownloader
         ModBase.Log($"[Download] 开始下载：{url} -> {localPath}");
         CleanupTempFiles(localPath);
 
+        var expectedSize = trackedFile?.Check?.actualSize ?? -1;
+        var sequentialRequestKind = (expectedSize >= 0 && expectedSize < AdaptiveRangeDownloader.SmallFileThreshold) ||
+                                     (expectedSize < 0 && !enableParallelChunks)
+            ? DownloadRequestKind.SmallOrBatch
+            : DownloadRequestKind.LargeOrUnknown;
+
         if (enableParallelChunks && await AdaptiveRangeDownloader.TryDownloadAsync(url, localPath,
                 useBrowserUserAgent, customUserAgent, cancellationToken, trackedFile,
-                trackedFile?.Check?.actualSize ?? -1).ConfigureAwait(false))
+                expectedSize).ConfigureAwait(false))
         {
             PromoteTempFile(localPath);
             if (!File.Exists(localPath))
@@ -92,17 +99,18 @@ public static class FileDownloader
         }
 
         await DownloadSequentiallyAsync(url, localPath, useBrowserUserAgent, customUserAgent, cancellationToken,
-            trackedFile).ConfigureAwait(false);
+            trackedFile, sequentialRequestKind).ConfigureAwait(false);
     }
 
     private static async Task DownloadSequentiallyAsync(string url, string localPath, bool useBrowserUserAgent,
-        string customUserAgent, CancellationToken cancellationToken, DownloadFile? trackedFile)
+        string customUserAgent, CancellationToken cancellationToken, DownloadFile? trackedFile,
+        DownloadRequestKind requestKind)
     {
         const int bufferSize = 64 * 1024;
         const int readTimeoutMilliseconds = 30_000;
         using var connection = await DownloadResourceManager.AcquireConnectionAsync(url, cancellationToken)
             .ConfigureAwait(false);
-        using var request = CreateDownloadRequest(url, useBrowserUserAgent, customUserAgent);
+        using var request = CreateDownloadRequest(url, useBrowserUserAgent, customUserAgent, requestKind);
         using var response = await GetHttpClient(url)
             .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
@@ -199,13 +207,44 @@ public static class FileDownloader
     }
 
     internal static HttpRequestMessage CreateDownloadRequest(string url, bool useBrowserUserAgent,
-        string customUserAgent)
+        string customUserAgent, DownloadRequestKind requestKind)
     {
         var request = new HttpRequestMessage(HttpMethod.Get, url);
         RequestSigning.SecretHeadersSign(url, ref request, useBrowserUserAgent, customUserAgent);
-        request.Version = HttpVersion.Version11;
-        request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
+        ApplyHttpVersion(request, requestKind);
         return request;
+    }
+
+    private static void ApplyHttpVersion(HttpRequestMessage request, DownloadRequestKind requestKind)
+    {
+        switch (Config.Download.HttpMode)
+        {
+            case DownloadHttpMode.Http11:
+                request.Version = HttpVersion.Version11;
+                request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
+                return;
+            case DownloadHttpMode.Http2:
+                request.Version = HttpVersion.Version20;
+                request.VersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
+                return;
+        }
+
+        // 自动模式规则：
+        // 1. 已知小于 4 MiB 的文件，以及批量任务中的顺序下载，优先 HTTP/2，
+        //    让大量小文件复用连接并通过多个 Stream 并发传输。
+        // 2. Range 探测、Range 分段，以及大小未知的单文件下载使用 HTTP/1.1，
+        //    让大文件分段获得独立 TCP 连接；Range 不可用时也避免再次切换协议。
+        // 3. HTTP/2 使用 RequestVersionOrLower，源站或代理不支持时自动回退到 HTTP/1.1。
+        if (requestKind == DownloadRequestKind.SmallOrBatch)
+        {
+            request.Version = HttpVersion.Version20;
+            request.VersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
+        }
+        else
+        {
+            request.Version = HttpVersion.Version11;
+            request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
+        }
     }
 
     private static void MarkDownloadCompleted(DownloadFile? trackedFile)
@@ -272,4 +311,12 @@ public static class FileDownloader
         
         return NetworkService.GetClient();
     }
+}
+
+internal enum DownloadRequestKind
+{
+    SmallOrBatch,
+    LargeOrUnknown,
+    RangeProbe,
+    RangeSegment
 }

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
@@ -1,6 +1,8 @@
+using System.Buffers;
+using System.Diagnostics;
 using System.IO;
+using System.Net.Http.Headers;
 using System.Net.Http;
-using Downloader;
 using PCL.Core.IO.Net;
 
 
@@ -77,118 +79,168 @@ public static class FileDownloader
         ModBase.Log($"[Download] 开始下载：{url} -> {localPath}");
         CleanupTempFiles(localPath);
 
-        var perFileThreadLimit = enableParallelChunks ? Math.Max(1, ModNet.NetTaskThreadLimit) : 1;
-        // 限制最大分块数，防止大文件下载时内存爆炸
-        var chunkCount = Math.Min(perFileThreadLimit, 4);
-        var configuration = new DownloadConfiguration
+        if (enableParallelChunks && await AdaptiveRangeDownloader.TryDownloadAsync(url, localPath,
+                useBrowserUserAgent, customUserAgent, cancellationToken, trackedFile).ConfigureAwait(false))
         {
-            ChunkCount = chunkCount,
-            ParallelCount = chunkCount,
-            ParallelDownload = chunkCount > 1,
-            MaximumBytesPerSecond = ModNet.NetTaskSpeedLimitHigh > 0 ? ModNet.NetTaskSpeedLimitHigh : 0,
-            MaxTryAgainOnFailure = 2,
-            BlockTimeout = 60000,
-            DownloadFileExtension = ModNet.netDownloadEnd,
-            EnableAutoResumeDownload = false,
-            CustomHttpClientFactory = () => GetHttpClient(url),
-            MinimumSizeOfChunking = 1024 * 1024L,
-            MaximumMemoryBufferBytes = 256L * 1024 * 1024,
-        };
-
-        using var downloader = new DownloadService(configuration);
-        using var cancelReg = cancellationToken.Register(() =>
-        {
-            try { downloader.CancelAsync(); } catch {  } // 忽略
-        });
-        var tcs = new TaskCompletionSource<bool>();
-        void UpdateDownloadStat(DownloadProgressChangedEventArgs args)
-        {
-            if (trackedFile is null)
-                return;
-
-            trackedFile.State = PCL.Network.NetState.Downloading;
-            trackedFile.TotalSize = Math.Max(trackedFile.TotalSize, args.TotalBytesToReceive);
-            trackedFile.IsUnknownSize = trackedFile.TotalSize <= 0;
-            trackedFile.DownloadedBytes = Math.Max(trackedFile.DownloadedBytes, args.ReceivedBytesSize);
-            trackedFile.Speed = Math.Max(0L, (long)Math.Round(args.BytesPerSecondSpeed));
-            trackedFile.ActiveThreads = Math.Max(0, args.ActiveChunks);
+            PromoteTempFile(localPath);
+            if (!File.Exists(localPath))
+                throw new IOException($"分段下载未产生任何文件：{localPath}");
+            MarkDownloadCompleted(trackedFile);
+            ModBase.Log($"[Download] 分段下载成功：{localPath}");
+            return;
         }
 
-        downloader.DownloadStarted += (_, args) =>
-        {
-            if (trackedFile is null)
-                return;
+        await DownloadSequentiallyAsync(url, localPath, useBrowserUserAgent, customUserAgent, cancellationToken,
+            trackedFile).ConfigureAwait(false);
+    }
 
-            trackedFile.State = PCL.Network.NetState.Reading;
-            trackedFile.TotalSize = Math.Max(trackedFile.TotalSize, args.TotalBytesToReceive);
-            trackedFile.IsUnknownSize = args.TotalBytesToReceive <= 0;
+    private static async Task DownloadSequentiallyAsync(string url, string localPath, bool useBrowserUserAgent,
+        string customUserAgent, CancellationToken cancellationToken, DownloadFile? trackedFile)
+    {
+        const int bufferSize = 64 * 1024;
+        const int readTimeoutMilliseconds = 60_000;
+        using var connection = await DownloadResourceManager.AcquireConnectionAsync(url, cancellationToken)
+            .ConfigureAwait(false);
+        using var request = CreateDownloadRequest(url, useBrowserUserAgent, customUserAgent);
+        request.Headers.AcceptEncoding.Clear();
+        request.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("identity"));
+        using var response = await GetHttpClient(url)
+            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+            throw new HttpRequestException($"下载请求失败：{(int)response.StatusCode} {response.ReasonPhrase}");
+
+        var totalSize = response.Content.Headers.ContentLength ?? -1;
+        if (trackedFile is not null)
+        {
+            trackedFile.State = PCL.Network.NetState.Downloading;
+            trackedFile.TotalSize = totalSize;
+            trackedFile.IsUnknownSize = totalSize <= 0;
             trackedFile.DownloadedBytes = 0;
             trackedFile.Speed = 0;
-            trackedFile.ActiveThreads = 0;
-        };
-        downloader.DownloadProgressChanged += (_, args) => UpdateDownloadStat(args);
-        downloader.ChunkDownloadProgressChanged += (_, args) => UpdateDownloadStat(args);
-        downloader.DownloadFileCompleted += (_, args) =>
-        {
-            if (trackedFile is not null)
-            {
-                trackedFile.Speed = 0;
-                trackedFile.ActiveThreads = 0;
-                trackedFile.DownloadedBytes = Math.Max(trackedFile.DownloadedBytes, trackedFile.TotalSize);
-            }
+            trackedFile.ActiveThreads = 1;
+        }
 
-            if (args.Cancelled)
-                tcs.TrySetCanceled();
-            else if (args.Error != null)
-                tcs.TrySetException(args.Error);
-            else
-                tcs.TrySetResult(true);
-        };
-        try
+        long downloaded = 0;
+        long lastProgressBytes = 0;
+        var lastProgressTick = Stopwatch.GetTimestamp();
+        await using var input = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        await using var output = new FileStream(localPath + ModNet.NetDownloadEnd, FileMode.Create, FileAccess.Write,
+            FileShare.Read, bufferSize: 1, FileOptions.Asynchronous | FileOptions.SequentialScan);
+        while (true)
         {
-            await downloader.DownloadFileTaskAsync(url, localPath, cancellationToken).ConfigureAwait(false);
-            await tcs.Task.ConfigureAwait(false);
-            var tempPath = localPath + ModNet.netDownloadEnd;
-            if (!File.Exists(localPath) && File.Exists(tempPath))
+            using var bufferLease = await DownloadResourceManager.ReserveBufferAsync(bufferSize, cancellationToken)
+                .ConfigureAwait(false);
+            var buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+            try
             {
-                for (var retry = 0; retry < 5; retry++)
+                int read;
+                using (var readTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
                 {
+                    readTimeout.CancelAfter(readTimeoutMilliseconds);
                     try
                     {
-                        File.Move(tempPath, localPath, true);
-                        break;
+                        read = await input.ReadAsync(buffer.AsMemory(0, bufferSize), readTimeout.Token)
+                            .ConfigureAwait(false);
                     }
-                    catch (IOException)
+                    catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested &&
+                                                           readTimeout.IsCancellationRequested)
                     {
-                        Thread.Sleep(100);
+                        throw new TimeoutException($"下载超时（{url}）");
                     }
                 }
+
+                if (read == 0)
+                    break;
+
+                await DownloadResourceManager.ThrottleAsync(read, cancellationToken).ConfigureAwait(false);
+                await output.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+                downloaded += read;
+                UpdateSequentialProgress(trackedFile, downloaded, totalSize, ref lastProgressBytes, ref lastProgressTick);
             }
-            if (!File.Exists(localPath))
-                throw new IOException($"下载未产生任何文件：{localPath}");
-            ModBase.Log($"[Download] 下载成功：{localPath}");
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
         }
-        catch (TaskCanceledException ex) when (cancellationToken.IsCancellationRequested)
+
+        await output.FlushAsync(cancellationToken).ConfigureAwait(false);
+        await output.DisposeAsync().ConfigureAwait(false);
+        if (totalSize >= 0 && downloaded != totalSize)
+            throw new IOException($"下载不完整：已写入 {downloaded}，应为 {totalSize}");
+
+        if (trackedFile is not null && totalSize <= 0)
         {
-            throw new OperationCanceledException(cancellationToken);
+            trackedFile.TotalSize = downloaded;
+            trackedFile.IsUnknownSize = false;
+            trackedFile.DownloadedBytes = downloaded;
         }
-        catch (TaskCanceledException ex)
+
+        PromoteTempFile(localPath);
+        if (!File.Exists(localPath))
+            throw new IOException($"下载未产生任何文件：{localPath}");
+        MarkDownloadCompleted(trackedFile);
+        ModBase.Log($"[Download] 顺序下载成功：{localPath}");
+    }
+
+    private static void UpdateSequentialProgress(DownloadFile? trackedFile, long downloaded, long totalSize,
+        ref long lastProgressBytes, ref long lastProgressTick)
+    {
+        if (trackedFile is null)
+            return;
+
+        var now = Stopwatch.GetTimestamp();
+        if (now - lastProgressTick < Stopwatch.Frequency / 5 && (totalSize <= 0 || downloaded < totalSize))
+            return;
+
+        var elapsed = Math.Max(1L, now - lastProgressTick);
+        trackedFile.DownloadedBytes = downloaded;
+        trackedFile.Speed = Math.Max(0L, (long)((downloaded - lastProgressBytes) * (double)Stopwatch.Frequency / elapsed));
+        trackedFile.ActiveThreads = 1;
+        lastProgressBytes = downloaded;
+        lastProgressTick = now;
+    }
+
+    internal static HttpRequestMessage CreateDownloadRequest(string url, bool useBrowserUserAgent,
+        string customUserAgent)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        RequestSigning.SecretHeadersSign(url, ref request, useBrowserUserAgent, customUserAgent);
+        return request;
+    }
+
+    private static void MarkDownloadCompleted(DownloadFile? trackedFile)
+    {
+        if (trackedFile is null)
+            return;
+
+        trackedFile.Speed = 0;
+        trackedFile.ActiveThreads = 0;
+        trackedFile.DownloadedBytes = Math.Max(trackedFile.DownloadedBytes, trackedFile.TotalSize);
+    }
+
+    private static void PromoteTempFile(string localPath)
+    {
+        var tempPath = localPath + ModNet.NetDownloadEnd;
+        if (File.Exists(localPath) || !File.Exists(tempPath))
+            return;
+
+        for (var retry = 0; retry < 5; retry++)
         {
-            throw new TimeoutException($"下载超时（{url}）", ex);
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            throw new IOException($"下载失败：{url}", ex);
+            try
+            {
+                File.Move(tempPath, localPath, true);
+                return;
+            }
+            catch (IOException) when (retry < 4)
+            {
+                Thread.Sleep(100);
+            }
         }
     }
 
     private static void CleanupTempFiles(string localPath)
     {
-        var tempPath = localPath + ModNet.netDownloadEnd;
+        var tempPath = localPath + ModNet.NetDownloadEnd;
         TryDeleteFile(localPath);
         TryDeleteFile(tempPath);
     }
@@ -210,7 +262,7 @@ public static class FileDownloader
         }
     }
 
-    private static HttpClient GetHttpClient(string url)
+    internal static HttpClient GetHttpClient(string url)
     {
         if (Uri.TryCreate(url, UriKind.Absolute, out var parsedUri)
             && parsedUri.Host is "edge.forgecdn.net" or "mediafilez.forgecdn.net" or "forgecdn.net" or "api.curseforge.com")

--- a/Plain Craft Launcher 2/Modules/Network/Facade/ModNet.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Facade/ModNet.cs
@@ -8,7 +8,8 @@ public static class ModNet
     public const string NetDownloadEnd = ".PCLDownloading";
     public const int NetTaskConnectionLimitMax = 256;
     public const int NetTaskSingleFileConnectionLimitMax = 8;
-    public const int NetTaskConnectionsPerHostLimit = 8;
+    // 主机级限制不再低于全局设置；默认仍由 NetTaskConnectionLimit（64）控制。
+    public const int NetTaskConnectionsPerHostLimit = NetTaskConnectionLimitMax;
     public const long NetTaskBufferBudgetBytes = 512L * 1024 * 1024;
 
     /// <summary>所有下载任务共享的最大活跃 HTTP 连接数。</summary>

--- a/Plain Craft Launcher 2/Modules/Network/Facade/ModNet.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Facade/ModNet.cs
@@ -5,8 +5,25 @@ namespace PCL.Network;
 
 public static class ModNet
 {
-    public const string netDownloadEnd = ".PCLDownloading";
-    public static int NetTaskThreadLimit { get; set; } = 16;
+    public const string NetDownloadEnd = ".PCLDownloading";
+    public const int NetTaskConnectionLimitMax = 256;
+    public const int NetTaskSingleFileConnectionLimitMax = 8;
+    public const int NetTaskConnectionsPerHostLimit = 8;
+    public const long NetTaskBufferBudgetBytes = 512L * 1024 * 1024;
+
+    /// <summary>所有下载任务共享的最大活跃 HTTP 连接数。</summary>
+    public static int NetTaskConnectionLimit { get; set; } = 64;
+
+    /// <summary>单个大文件可同时使用的最大连接数。</summary>
+    public static int NetTaskSingleFileConnectionLimit { get; set; } = 8;
+
+    [Obsolete("请使用 NetTaskConnectionLimit。")]
+    public static int NetTaskThreadLimit
+    {
+        get => NetTaskConnectionLimit;
+        set => NetTaskConnectionLimit = value;
+    }
+
     public static long NetTaskSpeedLimitLow { get; set; } = 256 * 1024L;
     public static long NetTaskSpeedLimitHigh { get; set; } = -1;
     public static long NetTaskSpeedLimitLeft { get; set; } = -1;

--- a/Plain Craft Launcher 2/Modules/Network/Http/Requester.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Http/Requester.cs
@@ -133,34 +133,6 @@ public static class Requester
         }
     }
 
-    public static async Task DownloadFileAsync(string url, string filePath)
-    {
-        await FileDownloader.DownloadAsync(url, filePath).ConfigureAwait(false);
-    }
-
-    public static async Task DownloadFileOnceAsync(string url, string filePath)
-    {
-        await FileDownloader.DownloadAsync(url, filePath).ConfigureAwait(false);
-    }
-
-    public static DownloadService CreateDownloadService(string url, bool useBrowserUserAgent = false)
-    {
-        var chunkCount = Math.Min(Math.Clamp(ModNet.NetTaskConnectionLimit, 1,
-            ModNet.NetTaskSingleFileConnectionLimitMax), ModNet.NetTaskSingleFileConnectionLimit);
-        return new DownloadService(new DownloadConfiguration
-        {
-            ChunkCount = chunkCount,
-            ParallelCount = chunkCount,
-            ParallelDownload = chunkCount > 1,
-            MaximumBytesPerSecond = ModNet.NetTaskSpeedLimitHigh > 0 ? ModNet.NetTaskSpeedLimitHigh : 0,
-            DownloadFileExtension = ModNet.NetDownloadEnd,
-            EnableAutoResumeDownload = false,
-            MaximumMemoryBufferBytes = 2L * 1024 * 1024,
-            BufferBlockSize = 64 * 1024,
-            RequestConfiguration = DownloadRequestFactory.Create(url, useBrowserUserAgent)
-        });
-    }
-
     public static HttpMethod ParseMethod(string? method)
     {
         return (method ?? "GET").ToUpperInvariant() switch

--- a/Plain Craft Launcher 2/Modules/Network/Http/Requester.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Http/Requester.cs
@@ -145,16 +145,18 @@ public static class Requester
 
     public static DownloadService CreateDownloadService(string url, bool useBrowserUserAgent = false)
     {
-        var chunkCount = Math.Min(Math.Max(1, ModNet.NetTaskThreadLimit), 4);
+        var chunkCount = Math.Min(Math.Clamp(ModNet.NetTaskConnectionLimit, 1,
+            ModNet.NetTaskSingleFileConnectionLimitMax), ModNet.NetTaskSingleFileConnectionLimit);
         return new DownloadService(new DownloadConfiguration
         {
             ChunkCount = chunkCount,
             ParallelCount = chunkCount,
             ParallelDownload = chunkCount > 1,
             MaximumBytesPerSecond = ModNet.NetTaskSpeedLimitHigh > 0 ? ModNet.NetTaskSpeedLimitHigh : 0,
-            DownloadFileExtension = ModNet.netDownloadEnd,
+            DownloadFileExtension = ModNet.NetDownloadEnd,
             EnableAutoResumeDownload = false,
-            MaximumMemoryBufferBytes = 256L * 1024 * 1024,
+            MaximumMemoryBufferBytes = 2L * 1024 * 1024,
+            BufferBlockSize = 64 * 1024,
             RequestConfiguration = DownloadRequestFactory.Create(url, useBrowserUserAgent)
         });
     }

--- a/Plain Craft Launcher 2/Modules/Network/Loaders/LoaderDownload.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Loaders/LoaderDownload.cs
@@ -131,8 +131,9 @@ public class LoaderDownload : ModLoader.LoaderBase
         }
 
         file.State = PCL.Network.NetState.Connecting;
-        // 全局资源管理器会限制总连接数，因此多个大文件也可安全地使用分段下载。
-        const bool enableParallelChunks = true;
+        // 批量任务中未知大小的文件直接下载，避免小文件逐个产生一次 Range 探测。
+        var expectedSize = file.Check?.actualSize ?? -1;
+        var enableParallelChunks = files.Count <= 1 || expectedSize >= AdaptiveRangeDownloader.SmallFileThreshold;
         for (var retry = 0; retry < 4; retry++)
         {
             cancellationToken.ThrowIfCancellationRequested();

--- a/Plain Craft Launcher 2/Modules/Network/Loaders/LoaderDownload.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Loaders/LoaderDownload.cs
@@ -117,17 +117,24 @@ public class LoaderDownload : ModLoader.LoaderBase
         if (State >= ModBase.LoadState.Finished)
             return;
         Directory.CreateDirectory(Path.GetDirectoryName(file.LocalPath) ?? throw new IOException("下载路径无效"));
-        if (file.Check?.canUseExistsFile == true && file.Check.Check(file.LocalPath) is null)
+        var checker = file.Check;
+        if (checker?.canUseExistsFile == true && File.Exists(file.LocalPath))
         {
-            file.IsCopy = true;
-            file.State = PCL.Network.NetState.Finished;
-            try { file.TotalSize = new FileInfo(file.LocalPath).Length; }
-            catch (IOException) { file.TotalSize = -1; }
-            file.DownloadedBytes = file.TotalSize;
-            file.Speed = 0;
-            file.ActiveThreads = 0;
-            OnFileFinish(file);
-            return;
+            var checkResult = string.IsNullOrEmpty(checker.hash)
+                ? checker.Check(file.LocalPath)
+                : await Task.Run(() => checker.Check(file.LocalPath), cancellationToken).ConfigureAwait(false);
+            if (checkResult is null)
+            {
+                file.IsCopy = true;
+                file.State = PCL.Network.NetState.Finished;
+                try { file.TotalSize = new FileInfo(file.LocalPath).Length; }
+                catch (IOException) { file.TotalSize = -1; }
+                file.DownloadedBytes = file.TotalSize;
+                file.Speed = 0;
+                file.ActiveThreads = 0;
+                OnFileFinish(file);
+                return;
+            }
         }
 
         file.State = PCL.Network.NetState.Connecting;

--- a/Plain Craft Launcher 2/Modules/Network/Loaders/LoaderDownload.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Loaders/LoaderDownload.cs
@@ -2,7 +2,6 @@ using System.Collections.Concurrent;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using PCL.Core.Utils;
 
 namespace PCL.Network.Loaders;
 
@@ -141,25 +140,8 @@ public class LoaderDownload : ModLoader.LoaderBase
         // 批量任务中未知大小的文件直接下载，避免小文件逐个产生一次 Range 探测。
         var expectedSize = file.Check?.actualSize ?? -1;
         var enableParallelChunks = files.Count <= 1 || expectedSize >= AdaptiveRangeDownloader.SmallFileThreshold;
-        for (var retry = 0; retry < 4; retry++)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            try
-            {
-                await FileDownloader.DownloadAsync(file.Urls, file.LocalPath, file.UseBrowserUserAgent, file.CustomUserAgent,
-                    cancellationToken, enableParallelChunks, file).ConfigureAwait(false);
-                break;
-            }
-            catch (OperationCanceledException)
-            {
-                throw;
-            }
-            catch (Exception ex) when (retry < 3)
-            {
-                ModBase.Log(ex, $"[Download] 重试 {retry + 1}/3：{file.LocalPath}", ModBase.LogLevel.Debug);
-                Thread.Sleep(RandomUtils.NextInt(300, 500 + retry * 300));
-            }
-        }
+        await FileDownloader.DownloadAsync(file.Urls, file.LocalPath, file.UseBrowserUserAgent, file.CustomUserAgent,
+            cancellationToken, enableParallelChunks, file).ConfigureAwait(false);
         try { file.TotalSize = new FileInfo(file.LocalPath).Length; }
         catch (IOException) { file.TotalSize = -1; }
         file.IsUnknownSize = file.TotalSize < 0;

--- a/Plain Craft Launcher 2/Modules/Network/Loaders/LoaderDownload.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Loaders/LoaderDownload.cs
@@ -105,7 +105,8 @@ public class LoaderDownload : ModLoader.LoaderBase
 
     private int GetMaxParallelFiles()
     {
-        return Math.Max(1, Math.Min(files.Count, Math.Clamp(ModNet.NetTaskThreadLimit, 1, 64)));
+        return Math.Max(1, Math.Min(files.Count,
+            Math.Clamp(ModNet.NetTaskConnectionLimit, 1, ModNet.NetTaskConnectionLimitMax)));
     }
 
     private async Task ProcessFileAsync(PCL.Network.DownloadFile file, CancellationToken cancellationToken)
@@ -130,7 +131,8 @@ public class LoaderDownload : ModLoader.LoaderBase
         }
 
         file.State = PCL.Network.NetState.Connecting;
-        var enableParallelChunks = files.Count <= 1;
+        // 全局资源管理器会限制总连接数，因此多个大文件也可安全地使用分段下载。
+        const bool enableParallelChunks = true;
         for (var retry = 0; retry < 4; retry++)
         {
             cancellationToken.ThrowIfCancellationRequested();

--- a/Plain Craft Launcher 2/Modules/Network/Management/NetManager.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Management/NetManager.cs
@@ -34,11 +34,7 @@ public sealed class NetManager
 
     public long Speed
     {
-        get
-        {
-            lock (LockFiles)
-                return Files.Values.Sum(file => file.Speed);
-        }
+        get => DownloadResourceManager.DownloadSpeed;
     }
 
     public int ConnectionCount

--- a/Plain Craft Launcher 2/Modules/Network/Management/NetManager.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Management/NetManager.cs
@@ -41,7 +41,7 @@ public sealed class NetManager
         }
     }
 
-    public int ThreadCount
+    public int ConnectionCount
     {
         get
         {
@@ -49,6 +49,9 @@ public sealed class NetManager
                 return Files.Values.Sum(file => file.ActiveThreads);
         }
     }
+
+    [Obsolete("请使用 ConnectionCount。")]
+    public int ThreadCount => ConnectionCount;
 
     public void Start(PCL.Network.Loaders.LoaderDownload task)
     {

--- a/Plain Craft Launcher 2/Modules/Network/Management/NetManager.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Management/NetManager.cs
@@ -43,11 +43,7 @@ public sealed class NetManager
 
     public int ConnectionCount
     {
-        get
-        {
-            lock (LockFiles)
-                return Files.Values.Sum(file => file.ActiveThreads);
-        }
+        get => DownloadResourceManager.ActiveConnectionCount;
     }
 
     [Obsolete("请使用 ConnectionCount。")]

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml
@@ -23,6 +23,7 @@
                             <RowDefinition Height="27" />
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="27" />
+                            <RowDefinition Height="27" />
                         </Grid.RowDefinitions>
                         <TextBlock VerticalAlignment="Center" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Source.File}" Margin="0,0,25,0" />
                         <local:MyComboBox x:Name="ComboDownloadSource" Grid.ColumnSpan="2" Tag="ToolDownloadSource"
@@ -45,18 +46,23 @@
                                         PreviewChange="SliderDownloadThread_PreviewChange"
                                         MaxValue="255" Value="63" Grid.Column="1" Change="SliderChange"
                                          ToolTip="{DynamicResource Setup.GameManage.Download.Threads.ToolTip}" />
-                        <TextBlock VerticalAlignment="Center" Grid.Row="5" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.SpeedLimit}"
+                        <TextBlock VerticalAlignment="Center" Grid.Row="5" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.FileConnections}"
                                    Margin="0,0,25,0" />
-                        <local:MySlider x:Name="SliderDownloadSpeed" Grid.Row="5" Tag="ToolDownloadSpeed" MaxValue="42"
+                        <local:MySlider x:Name="SliderDownloadFileConnection" Grid.Row="5" Tag="ToolDownloadFileConnection"
+                                        MaxValue="7" Value="7" Grid.Column="1" Change="SliderChange"
+                                        ToolTip="{DynamicResource Setup.GameManage.Download.FileConnections.ToolTip}" />
+                        <TextBlock VerticalAlignment="Center" Grid.Row="6" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.SpeedLimit}"
+                                   Margin="0,0,25,0" />
+                        <local:MySlider x:Name="SliderDownloadSpeed" Grid.Row="6" Tag="ToolDownloadSpeed" MaxValue="42"
                                         Value="42" Grid.Column="1" Change="SliderChange"
                                          ToolTip="{DynamicResource Setup.GameManage.Download.SpeedLimit.ToolTip}" />
-                        <TextBlock VerticalAlignment="Top" Grid.Row="6" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.TargetFolder}"
+                        <TextBlock VerticalAlignment="Top" Grid.Row="7" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.TargetFolder}"
                                    Margin="0,5,25,5" />
                         <TextBlock Margin="0,5" HorizontalAlignment="Left"
-                                   Text="{DynamicResource Setup.GameManage.Download.TargetFolder.Hint}" Grid.Row="6"
+                                   Text="{DynamicResource Setup.GameManage.Download.TargetFolder.Hint}" Grid.Row="7"
                                    Grid.Column="1" VerticalAlignment="Center" Opacity="0.5" />
-                        <TextBlock Margin="0,5" Grid.Row="7" Text="{DynamicResource Setup.GameManage.Download.InstallBehavior}" />
-                        <Grid Grid.Row="7" Grid.Column="1">
+                        <TextBlock Margin="0,5" Grid.Row="8" Text="{DynamicResource Setup.GameManage.Download.InstallBehavior}" />
+                        <Grid Grid.Row="8" Grid.Column="1">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="*" />

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml
@@ -18,13 +18,11 @@
                             <RowDefinition Height="28" />
                             <RowDefinition Height="7" />
                             <RowDefinition Height="28" />
-                            <RowDefinition Height="10" />
+                            <RowDefinition Height="7" />
+                            <RowDefinition Height="27" />
+                            <RowDefinition Height="27" />
+                            <RowDefinition Height="27" />
                             <RowDefinition Height="Auto" />
-                            <RowDefinition Height="10" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="10" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="5" />
                             <RowDefinition Height="27" />
                             <RowDefinition Height="27" />
                         </Grid.RowDefinitions>
@@ -49,23 +47,34 @@
                                         PreviewChange="SliderDownloadThread_PreviewChange"
                                         MaxValue="255" Value="63" Grid.Column="1" Change="SliderChange"
                                          ToolTip="{DynamicResource Setup.GameManage.Download.Threads.ToolTip}" />
-                        <TextBlock VerticalAlignment="Center" Grid.Row="6" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.FileConnections}"
+                        <TextBlock VerticalAlignment="Center" Grid.Row="5" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.FileConnections}"
                                    Margin="0,0,25,0" />
-                        <local:MySlider x:Name="SliderDownloadFileConnection" Grid.Row="6" Tag="ToolDownloadFileConnection"
+                        <local:MySlider x:Name="SliderDownloadFileConnection" Grid.Row="5" Tag="ToolDownloadFileConnection"
                                         MaxValue="7" Value="7" Grid.Column="1" Change="SliderChange"
                                         ToolTip="{DynamicResource Setup.GameManage.Download.FileConnections.ToolTip}" />
-                        <TextBlock VerticalAlignment="Center" Grid.Row="8" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.SpeedLimit}"
+                        <TextBlock VerticalAlignment="Center" Grid.Row="6" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.HttpProtocol}"
                                    Margin="0,0,25,0" />
-                        <local:MySlider x:Name="SliderDownloadSpeed" Grid.Row="8" Tag="ToolDownloadSpeed" MaxValue="42"
+                        <local:MyComboBox x:Name="ComboDownloadHttpMode" Grid.Row="6" Grid.Column="1"
+                                          Tag="ToolDownloadHttpMode" SelectionChanged="ComboChange">
+                            <local:MyComboBoxItem Content="{DynamicResource Setup.GameManage.Download.HttpProtocol.Auto}"
+                                                  ToolTip="{DynamicResource Setup.GameManage.Download.HttpProtocol.Auto.ToolTip}" />
+                            <local:MyComboBoxItem Content="{DynamicResource Setup.GameManage.Download.HttpProtocol.Http11}"
+                                                  ToolTip="{DynamicResource Setup.GameManage.Download.HttpProtocol.Http11.ToolTip}" />
+                            <local:MyComboBoxItem Content="{DynamicResource Setup.GameManage.Download.HttpProtocol.Http2}"
+                                                  ToolTip="{DynamicResource Setup.GameManage.Download.HttpProtocol.Http2.ToolTip}" />
+                        </local:MyComboBox>
+                        <TextBlock VerticalAlignment="Center" Grid.Row="7" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.SpeedLimit}"
+                                   Margin="0,0,25,0" />
+                        <local:MySlider x:Name="SliderDownloadSpeed" Grid.Row="7" Tag="ToolDownloadSpeed" MaxValue="42"
                                         Value="42" Grid.Column="1" Change="SliderChange"
                                          ToolTip="{DynamicResource Setup.GameManage.Download.SpeedLimit.ToolTip}" />
-                        <TextBlock VerticalAlignment="Top" Grid.Row="10" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.TargetFolder}"
+                        <TextBlock VerticalAlignment="Top" Grid.Row="8" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.TargetFolder}"
                                    Margin="0,5,25,5" />
                         <TextBlock Margin="0,5" HorizontalAlignment="Left"
-                                   Text="{DynamicResource Setup.GameManage.Download.TargetFolder.Hint}" Grid.Row="10"
+                                   Text="{DynamicResource Setup.GameManage.Download.TargetFolder.Hint}" Grid.Row="8"
                                    Grid.Column="1" VerticalAlignment="Center" Opacity="0.5" />
-                        <TextBlock Margin="0,5" Grid.Row="11" Text="{DynamicResource Setup.GameManage.Download.InstallBehavior}" />
-                        <Grid Grid.Row="11" Grid.Column="1">
+                        <TextBlock Margin="0,5" Grid.Row="9" Text="{DynamicResource Setup.GameManage.Download.InstallBehavior}" />
+                        <Grid Grid.Row="9" Grid.Column="1">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="*" />

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml
@@ -20,9 +20,10 @@
                             <RowDefinition Height="28" />
                             <RowDefinition Height="7" />
                             <RowDefinition Height="27" />
+                            <RowDefinition Height="7" />
                             <RowDefinition Height="27" />
                             <RowDefinition Height="27" />
-                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="27" />
                             <RowDefinition Height="27" />
                             <RowDefinition Height="27" />
                         </Grid.RowDefinitions>
@@ -41,20 +42,9 @@
                             <local:MyComboBoxItem Content="{DynamicResource Setup.GameManage.Source.PreferOfficialThenMirror}" IsSelected="True" />
                             <local:MyComboBoxItem Content="{DynamicResource Setup.GameManage.Source.UseOfficial}" />
                         </local:MyComboBox>
-                        <TextBlock Grid.Row="4" VerticalAlignment="Center" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.Threads}"
+                        <TextBlock VerticalAlignment="Center" Grid.Row="4" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.HttpProtocol}"
                                    Margin="0,0,25,0" />
-                        <local:MySlider x:Name="SliderDownloadThread" Grid.Row="4" Tag="ToolDownloadThread"
-                                        PreviewChange="SliderDownloadThread_PreviewChange"
-                                        MaxValue="255" Value="63" Grid.Column="1" Change="SliderChange"
-                                         ToolTip="{DynamicResource Setup.GameManage.Download.Threads.ToolTip}" />
-                        <TextBlock VerticalAlignment="Center" Grid.Row="5" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.FileConnections}"
-                                   Margin="0,0,25,0" />
-                        <local:MySlider x:Name="SliderDownloadFileConnection" Grid.Row="5" Tag="ToolDownloadFileConnection"
-                                        MaxValue="7" Value="7" Grid.Column="1" Change="SliderChange"
-                                        ToolTip="{DynamicResource Setup.GameManage.Download.FileConnections.ToolTip}" />
-                        <TextBlock VerticalAlignment="Center" Grid.Row="6" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.HttpProtocol}"
-                                   Margin="0,0,25,0" />
-                        <local:MyComboBox x:Name="ComboDownloadHttpMode" Grid.Row="6" Grid.Column="1"
+                        <local:MyComboBox x:Name="ComboDownloadHttpMode" Grid.Row="4" Grid.Column="1"
                                           Tag="ToolDownloadHttpMode" SelectionChanged="ComboChange">
                             <local:MyComboBoxItem Content="{DynamicResource Setup.GameManage.Download.HttpProtocol.Auto}"
                                                   ToolTip="{DynamicResource Setup.GameManage.Download.HttpProtocol.Auto.ToolTip}" />
@@ -63,18 +53,29 @@
                             <local:MyComboBoxItem Content="{DynamicResource Setup.GameManage.Download.HttpProtocol.Http2}"
                                                   ToolTip="{DynamicResource Setup.GameManage.Download.HttpProtocol.Http2.ToolTip}" />
                         </local:MyComboBox>
-                        <TextBlock VerticalAlignment="Center" Grid.Row="7" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.SpeedLimit}"
+                        <TextBlock Grid.Row="6" VerticalAlignment="Center" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.Threads}"
                                    Margin="0,0,25,0" />
-                        <local:MySlider x:Name="SliderDownloadSpeed" Grid.Row="7" Tag="ToolDownloadSpeed" MaxValue="42"
+                        <local:MySlider x:Name="SliderDownloadThread" Grid.Row="6" Tag="ToolDownloadThread"
+                                        PreviewChange="SliderDownloadThread_PreviewChange"
+                                        MaxValue="255" Value="63" Grid.Column="1" Change="SliderChange"
+                                         ToolTip="{DynamicResource Setup.GameManage.Download.Threads.ToolTip}" />
+                        <TextBlock VerticalAlignment="Center" Grid.Row="7" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.FileConnections}"
+                                   Margin="0,0,25,0" />
+                        <local:MySlider x:Name="SliderDownloadFileConnection" Grid.Row="7" Tag="ToolDownloadFileConnection"
+                                        MaxValue="7" Value="7" Grid.Column="1" Change="SliderChange"
+                                        ToolTip="{DynamicResource Setup.GameManage.Download.FileConnections.ToolTip}" />
+                        <TextBlock VerticalAlignment="Center" Grid.Row="8" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.SpeedLimit}"
+                                   Margin="0,0,25,0" />
+                        <local:MySlider x:Name="SliderDownloadSpeed" Grid.Row="8" Tag="ToolDownloadSpeed" MaxValue="42"
                                         Value="42" Grid.Column="1" Change="SliderChange"
                                          ToolTip="{DynamicResource Setup.GameManage.Download.SpeedLimit.ToolTip}" />
-                        <TextBlock VerticalAlignment="Top" Grid.Row="8" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.TargetFolder}"
+                        <TextBlock VerticalAlignment="Top" Grid.Row="9" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.TargetFolder}"
                                    Margin="0,5,25,5" />
                         <TextBlock Margin="0,5" HorizontalAlignment="Left"
-                                   Text="{DynamicResource Setup.GameManage.Download.TargetFolder.Hint}" Grid.Row="8"
+                                   Text="{DynamicResource Setup.GameManage.Download.TargetFolder.Hint}" Grid.Row="9"
                                    Grid.Column="1" VerticalAlignment="Center" Opacity="0.5" />
-                        <TextBlock Margin="0,5" Grid.Row="9" Text="{DynamicResource Setup.GameManage.Download.InstallBehavior}" />
-                        <Grid Grid.Row="9" Grid.Column="1">
+                        <TextBlock Margin="0,5" Grid.Row="10" Text="{DynamicResource Setup.GameManage.Download.InstallBehavior}" />
+                        <Grid Grid.Row="10" Grid.Column="1">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="*" />

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml
@@ -18,10 +18,13 @@
                             <RowDefinition Height="28" />
                             <RowDefinition Height="7" />
                             <RowDefinition Height="28" />
-                            <RowDefinition Height="7" />
-                            <RowDefinition Height="27" />
-                            <RowDefinition Height="27" />
+                            <RowDefinition Height="10" />
                             <RowDefinition Height="Auto" />
+                            <RowDefinition Height="10" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="10" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="5" />
                             <RowDefinition Height="27" />
                             <RowDefinition Height="27" />
                         </Grid.RowDefinitions>
@@ -46,23 +49,23 @@
                                         PreviewChange="SliderDownloadThread_PreviewChange"
                                         MaxValue="255" Value="63" Grid.Column="1" Change="SliderChange"
                                          ToolTip="{DynamicResource Setup.GameManage.Download.Threads.ToolTip}" />
-                        <TextBlock VerticalAlignment="Center" Grid.Row="5" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.FileConnections}"
+                        <TextBlock VerticalAlignment="Center" Grid.Row="6" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.FileConnections}"
                                    Margin="0,0,25,0" />
-                        <local:MySlider x:Name="SliderDownloadFileConnection" Grid.Row="5" Tag="ToolDownloadFileConnection"
+                        <local:MySlider x:Name="SliderDownloadFileConnection" Grid.Row="6" Tag="ToolDownloadFileConnection"
                                         MaxValue="7" Value="7" Grid.Column="1" Change="SliderChange"
                                         ToolTip="{DynamicResource Setup.GameManage.Download.FileConnections.ToolTip}" />
-                        <TextBlock VerticalAlignment="Center" Grid.Row="6" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.SpeedLimit}"
+                        <TextBlock VerticalAlignment="Center" Grid.Row="8" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.SpeedLimit}"
                                    Margin="0,0,25,0" />
-                        <local:MySlider x:Name="SliderDownloadSpeed" Grid.Row="6" Tag="ToolDownloadSpeed" MaxValue="42"
+                        <local:MySlider x:Name="SliderDownloadSpeed" Grid.Row="8" Tag="ToolDownloadSpeed" MaxValue="42"
                                         Value="42" Grid.Column="1" Change="SliderChange"
                                          ToolTip="{DynamicResource Setup.GameManage.Download.SpeedLimit.ToolTip}" />
-                        <TextBlock VerticalAlignment="Top" Grid.Row="7" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.TargetFolder}"
+                        <TextBlock VerticalAlignment="Top" Grid.Row="10" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Download.TargetFolder}"
                                    Margin="0,5,25,5" />
                         <TextBlock Margin="0,5" HorizontalAlignment="Left"
-                                   Text="{DynamicResource Setup.GameManage.Download.TargetFolder.Hint}" Grid.Row="7"
+                                   Text="{DynamicResource Setup.GameManage.Download.TargetFolder.Hint}" Grid.Row="10"
                                    Grid.Column="1" VerticalAlignment="Center" Opacity="0.5" />
-                        <TextBlock Margin="0,5" Grid.Row="8" Text="{DynamicResource Setup.GameManage.Download.InstallBehavior}" />
-                        <Grid Grid.Row="8" Grid.Column="1">
+                        <TextBlock Margin="0,5" Grid.Row="11" Text="{DynamicResource Setup.GameManage.Download.InstallBehavior}" />
+                        <Grid Grid.Row="11" Grid.Column="1">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="*" />

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml.cs
@@ -51,7 +51,9 @@ public partial class PageSetupGameManage
     {
         // 下载
         SliderDownloadThread.Value = Config.Download.ThreadLimit;
+        SliderDownloadFileConnection.Value = Config.Download.FileConnectionLimit;
         SliderDownloadSpeed.Value = Config.Download.SpeedLimit;
+        ComboDownloadHttpMode.SelectedIndex = (int)Config.Download.HttpMode;
         ComboDownloadSource.SelectedIndex = Config.Download.FileSource;
         ComboDownloadVersion.SelectedIndex = Config.Download.VersionListSource;
         CheckDownloadAutoSelectVersion.Checked = Config.Download.AutoSelectInstance;

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml.cs
@@ -125,6 +125,7 @@ public partial class PageSetupGameManage
     private void SliderLoad()
     {
         SliderDownloadThread.getHintText = new Func<object, object>(v => (int)v + 1);
+        SliderDownloadFileConnection.getHintText = new Func<object, object>(v => (int)v + 1);
         SliderDownloadSpeed.getHintText = new Func<object, object>(v =>
         {
             int value = (int)v;
@@ -144,7 +145,7 @@ public partial class PageSetupGameManage
 
     private void SliderDownloadThread_PreviewChange(object sender, ModBase.RouteEventArgs e)
     {
-        if (SliderDownloadThread.Value < 100)
+        if (SliderDownloadThread.Value < 64)
             return;
         if (!States.Hint.LargeDownloadThread)
         {

--- a/Plain Craft Launcher 2/Pages/PageSpeedLeft.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSpeedLeft.xaml.cs
@@ -39,7 +39,7 @@ public partial class PageSpeedLeft
         timer.Tick += (_, _) => Watcher();
         timer.Start();
 
-        // 非调试模式隐藏线程数
+        // 非调试模式隐藏连接数
         if (!ModBase.modeDebug)
         {
             RowDefinitions[12].Height = new GridLength(0d);
@@ -63,7 +63,7 @@ public partial class PageSpeedLeft
                 LabProgress.Text = Lang.Number(1d, "P0");
                 LabSpeed.Text = ModBase.GetString(0) + "/s";
                 LabFile.Text = Lang.Number(0, "N0");
-                LabThread.Text = Lang.Number(0, "N0") + " / " + Lang.Number(ModNet.NetTaskThreadLimit, "N0");
+                LabThread.Text = Lang.Number(0, "N0") + " / " + Lang.Number(ModNet.NetTaskConnectionLimit, "N0");
             }
             else
             {
@@ -78,8 +78,8 @@ public partial class PageSpeedLeft
                 LabProgress.Text = rawPercent > 0.999999d ? Lang.Number(1d, "P0") : predictText;
                 LabSpeed.Text = ModBase.GetString(ModNet.NetManager.Speed) + "/s";
                 LabFile.Text = ModNet.NetManager.FileRemain < 0 ? "0*" : Lang.Number(ModNet.NetManager.FileRemain, "N0");
-                LabThread.Text = Lang.Number(ModNet.NetManager.ThreadCount, "N0") + " / " +
-                                 Lang.Number(ModNet.NetTaskThreadLimit, "N0");
+                LabThread.Text = Lang.Number(ModNet.NetManager.ConnectionCount, "N0") + " / " +
+                                 Lang.Number(ModNet.NetTaskConnectionLimit, "N0");
             }
         }
 


### PR DESCRIPTION
本 PR 对下载器的分片策略与系统资源分配进行了重构。

修改内容：针对文件下载回退到 HTTP/1.1（至少在我这里高峰期 1.1 的速度显著快于 2.0），元数据与 API 请求仍然使用 HTTP/2.0；仅针对大于 4 MiB 的文件尝试分片；批量任务中未知大小的文件直接下载，不进行 Range 探测；大文件下载采用新的动态分片机制，分片大小更加灵活；内存缓存改为全局共享，并及时将内容写入硬盘，避免极端情况下内存过高占用。

测试时进行 Minecraft 26.2 清洁安装，下载高峰阶段相比 PCL 2.13.1.0 的相同阶段内存占用可减少约 2/3（稳定在 180 - 220 MB），同时保持下载速度基本持平甚至略微更快；与 PCL CE 2.15.0 相比内存占用差距不大（此 PR 版本占用略微减少），主要改进了部分情况下下载速度极其缓慢的问题。

同时，close #3356 。

本 PR 主要使用 AI 完成，因此需要较为细致的测试与检查。同时，回退到 HTTP/1.1 还是保留 HTTP/2.0 可能仍需要进一步调查与讨论。

> Generated by GPT-5.6 Sol xHigh & GPT-5.6 Terra xHigh

## Summary by Sourcery

重构下载器的分片、连接管理和资源调度逻辑，以提升大文件下载性能、稳定性及内存使用效率。

New Features:
- 为下载任务增加 HTTP 协议模式、全局连接数和单文件连接数配置。
- 为大文件引入自适应 Range 并行下载，并支持慢速分片拆分、失败恢复及顺序下载回退。
- 引入全局下载资源管理，统一协调连接、缓冲区、带宽限速和下载监控。

Bug Fixes:
- 避免批量下载中对小文件和大小未知文件进行不必要的 Range 探测。
- 改进已存在文件复用、临时文件校验、下载完整性检查及下载源失败后的重试处理。

Enhancements:
- 将下载限制和监控从线程数调整为连接数，并增加全局及主机级连接控制。
- 通过共享缓冲区配额和增量写盘降低下载过程中的内存压力，并优化不同文件规模下的下载策略。

Chores:
- 移除旧的基于 DownloadService 的分块下载实现及相关接口。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构下载器的分片、连接管理和资源调度逻辑，以提升大文件下载性能、稳定性及内存使用效率。

New Features:
- 为下载任务增加 HTTP 协议模式、全局连接数和单文件连接数配置。
- 为大文件引入自适应 Range 并行下载，并支持慢速分片拆分、失败恢复及顺序下载回退。
- 引入全局下载资源管理，统一协调连接、缓冲区、带宽限速和下载监控。

Bug Fixes:
- 避免批量下载中对小文件和大小未知文件进行不必要的 Range 探测。
- 改进已存在文件复用、临时文件校验、下载完整性检查及下载源失败后的重试处理。

Enhancements:
- 将下载限制和监控从线程数调整为连接数，并增加全局及主机级连接控制。
- 通过共享缓冲区配额和增量写盘降低下载过程中的内存压力，并优化不同文件规模下的下载策略。

Chores:
- 移除旧的基于 DownloadService 的分块下载实现及相关接口。

</details>

<details>
<summary>Original summary in English</summary>



</details>

## Sourcery 总结

重构下载器，使其能够根据文件大小自适应分段并共享资源，从而提升大文件下载的可靠性和内存使用效率，同时改进连接控制和 HTTP 行为。

新功能：
- 添加可配置的 HTTP 协议选择和按文件设置的下载连接数限制。
- 为大文件引入基于范围的自适应并行下载，并支持慢速或失败分段的恢复。
- 添加对下载连接、内存缓冲区、带宽限制以及总体监控的全局共享管理。

错误修复：
- 在批量下载中，避免对小文件和大小未知的文件进行不必要的范围探测。
- 改进对现有已验证文件的复用，并扩展下载重试处理。

增强功能：
- 将面向线程的下载控制和监控替换为面向连接的限制和状态报告。
- 通过共享资源配额并将下载数据增量写入磁盘，降低下载器的内存压力。
- 改进小文件、大文件及批量文件的下载协议选择和性能。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

重构下载器的分片、资源管理与连接控制逻辑，以改善大文件下载性能、稳定性和内存使用。

新功能：
- 为大文件提供自适应 Range 并行下载，并支持慢速分片恢复。
- 新增下载 HTTP 协议选择和单文件连接数配置。
- 引入全局下载资源管理，统一协调连接、缓冲区、带宽和下载监控。

错误修复：
- 避免批量下载中对小文件或大小未知文件进行不必要的 Range 探测。
- 改进已校验本地文件复用、下载完整性校验和失败重试处理。

改进：
- 将下载控制与监控从线程数调整为连接数，并加入全局及主机级连接限制。
- 通过共享缓冲区配额和增量写盘降低下载过程中的内存占用。
- 优化不同文件规模和下载场景下的 HTTP 协议选择与下载策略。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

重构下载器的分片策略与资源管理，以提升大文件下载性能、稳定性和内存使用效率。

新功能：
- 为下载任务增加 HTTP 协议模式选择和单文件连接数配置。
- 为大文件引入自适应 Range 并行下载，并支持慢速分片拆分与失败恢复。
- 引入全局下载资源管理，统一协调连接、缓冲区、带宽限速和下载监控。

错误修复：
- 避免批量下载中对小文件或大小未知文件进行不必要的 Range 探测。
- 改进已校验本地文件复用、下载完整性校验以及下载源失败后的重试处理。

增强功能：
- 将下载限制和监控从线程数调整为连接数，并增加全局及主机级连接控制。
- 通过共享缓冲区配额和增量写盘降低下载过程中的内存占用。
- 根据文件规模和下载场景优化 HTTP/1.1 与 HTTP/2 的使用策略。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

重构下载器的分片、连接管理和资源调度逻辑，以提升大文件下载性能、稳定性及内存使用效率。

新功能：
- 为大文件引入自适应 Range 并行下载，并支持慢速分片拆分、失败恢复和协议选择。
- 新增全局下载资源管理，统一协调连接数、缓冲区、带宽限速和下载监控。
- 增加单文件连接数限制及 HTTP 下载模式配置，并保留旧配置的兼容映射。

错误修复：
- 避免批量下载中对小文件和大小未知文件进行不必要的 Range 探测。
- 改进已校验本地文件复用、临时文件校验、下载完整性检查和失败重试处理。

改进：
- 将下载控制和监控从线程数调整为连接数，并增加全局及主机级连接管理。
- 通过共享内存缓冲配额和增量写盘降低下载过程中的内存占用，并优化不同文件规模下的下载策略。

日常维护：
- 移除旧的基于 DownloadService 的分块下载实现及相关接口。

<details>
<summary>Original summary in English</summary>



</details>

</details>

</details>

</details>