### PR TITLE
feat(resource): 支持从其他实例导入资源包与光影包 [GPT-5.6]

### DIFF
--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -1069,9 +1069,12 @@
     <sys:String x:Key="Instance.Resource.ExportInfo">Export info</sys:String>
     <sys:String x:Key="Instance.Resource.ExportInfo.ToolTip">Export detailed version info for resources</sys:String>
     <sys:String x:Key="Instance.Resource.Favorite">Favorite</sys:String>
-    <sys:String x:Key="Instance.Resource.Import.FileCount">{0} file(s) available</sys:String>
-    <sys:String x:Key="Instance.Resource.Import.NoAvailableInstance">No other instance contains files available for import</sys:String>
+    <sys:String x:Key="Instance.Resource.Import.ItemCount">{0} resource item(s) available</sys:String>
+    <sys:String x:Key="Instance.Resource.Import.NoAvailableInstance">No other instance contains resources available for import</sys:String>
+    <sys:String x:Key="Instance.Resource.Import.OverwriteConfirm.Message">A resource named {0} already exists. Overwrite it?</sys:String>
+    <sys:String x:Key="Instance.Resource.Import.OverwriteConfirm.Title">Confirm resource overwrite</sys:String>
     <sys:String x:Key="Instance.Resource.Import.SelectInstance">Select source instance</sys:String>
+    <sys:String x:Key="Instance.Resource.Import.Success">Imported {0} resource item(s)</sys:String>
     <sys:String x:Key="Instance.Resource.ImportFromInstance">Import from another instance</sys:String>
     <sys:String x:Key="Instance.Resource.InstallFromFiles">Install from files</sys:String>
     <sys:String x:Key="Instance.Resource.List.Loading">Loading resource list</sys:String>

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -1069,6 +1069,10 @@
     <sys:String x:Key="Instance.Resource.ExportInfo">Export info</sys:String>
     <sys:String x:Key="Instance.Resource.ExportInfo.ToolTip">Export detailed version info for resources</sys:String>
     <sys:String x:Key="Instance.Resource.Favorite">Favorite</sys:String>
+    <sys:String x:Key="Instance.Resource.Import.FileCount">{0} file(s) available</sys:String>
+    <sys:String x:Key="Instance.Resource.Import.NoAvailableInstance">No other instance contains files available for import</sys:String>
+    <sys:String x:Key="Instance.Resource.Import.SelectInstance">Select source instance</sys:String>
+    <sys:String x:Key="Instance.Resource.ImportFromInstance">Import from another instance</sys:String>
     <sys:String x:Key="Instance.Resource.InstallFromFiles">Install from files</sys:String>
     <sys:String x:Key="Instance.Resource.List.Loading">Loading resource list</sys:String>
     <sys:String x:Key="Instance.Resource.Loading">Loading resource list</sys:String>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -1069,9 +1069,12 @@
     <sys:String x:Key="Instance.Resource.ExportInfo">导出信息</sys:String>
     <sys:String x:Key="Instance.Resource.ExportInfo.ToolTip">导出详细的资源的版本信息</sys:String>
     <sys:String x:Key="Instance.Resource.Favorite">收藏</sys:String>
-    <sys:String x:Key="Instance.Resource.Import.FileCount">{0} 个可导入文件</sys:String>
-    <sys:String x:Key="Instance.Resource.Import.NoAvailableInstance">没有找到包含可导入文件的其他实例</sys:String>
+    <sys:String x:Key="Instance.Resource.Import.ItemCount">{0} 个可导入资源</sys:String>
+    <sys:String x:Key="Instance.Resource.Import.NoAvailableInstance">没有找到包含可导入资源的其他实例</sys:String>
+    <sys:String x:Key="Instance.Resource.Import.OverwriteConfirm.Message">已存在同名资源：{0}，是否覆盖？</sys:String>
+    <sys:String x:Key="Instance.Resource.Import.OverwriteConfirm.Title">资源覆盖确认</sys:String>
     <sys:String x:Key="Instance.Resource.Import.SelectInstance">选择来源实例</sys:String>
+    <sys:String x:Key="Instance.Resource.Import.Success">已导入 {0} 个资源</sys:String>
     <sys:String x:Key="Instance.Resource.ImportFromInstance">从其他实例导入</sys:String>
     <sys:String x:Key="Instance.Resource.InstallFromFiles">从文件安装</sys:String>
     <sys:String x:Key="Instance.Resource.List.Loading">正在加载资源列表</sys:String>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -1069,6 +1069,10 @@
     <sys:String x:Key="Instance.Resource.ExportInfo">导出信息</sys:String>
     <sys:String x:Key="Instance.Resource.ExportInfo.ToolTip">导出详细的资源的版本信息</sys:String>
     <sys:String x:Key="Instance.Resource.Favorite">收藏</sys:String>
+    <sys:String x:Key="Instance.Resource.Import.FileCount">{0} 个可导入文件</sys:String>
+    <sys:String x:Key="Instance.Resource.Import.NoAvailableInstance">没有找到包含可导入文件的其他实例</sys:String>
+    <sys:String x:Key="Instance.Resource.Import.SelectInstance">选择来源实例</sys:String>
+    <sys:String x:Key="Instance.Resource.ImportFromInstance">从其他实例导入</sys:String>
     <sys:String x:Key="Instance.Resource.InstallFromFiles">从文件安装</sys:String>
     <sys:String x:Key="Instance.Resource.List.Loading">正在加载资源列表</sys:String>
     <sys:String x:Key="Instance.Resource.Loading">正在加载资源列表</sys:String>

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml
@@ -73,6 +73,8 @@
                                         Padding="12,0" Visibility="Collapsed" />
                         <local:MyButton Height="35" x:Name="BtnHintInstall" MinWidth="130" Text="{DynamicResource Instance.Resource.InstallFromFiles}" Margin="5,0"
                                         Padding="12,0" ColorType="Highlight" />
+                        <local:MyButton Height="35" x:Name="BtnHintImport" MinWidth="130" Text="{DynamicResource Instance.Resource.ImportFromInstance}" Margin="5,0"
+                                        Padding="12,0" Visibility="Collapsed" />
                         <local:MyButton Height="35" x:Name="BtnHintDownload" MinWidth="130" Text="{DynamicResource Instance.Resource.DownloadNew}" Margin="5,0"
                                         Padding="12,0" />
                         <local:MyButton Height="35" x:Name="BtnHintOpen" MinWidth="130" Text="{DynamicResource Common.Action.OpenFolder}" Margin="5,0"

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml
@@ -20,6 +20,8 @@
 
                             <local:MyButton x:Name="BtnManageInstall" MinWidth="110" Text="{DynamicResource Instance.Resource.InstallFromFiles}" Padding="13,7"
                                             Margin="0,7,15,0" HorizontalAlignment="Left" />
+                            <local:MyButton x:Name="BtnManageImport" MinWidth="110" Text="{DynamicResource Instance.Resource.ImportFromInstance}" Padding="13,7"
+                                            Margin="0,7,15,0" HorizontalAlignment="Left" Visibility="Collapsed" />
                             <local:MyButton x:Name="BtnManageDownload" MinWidth="110" Text="{DynamicResource Instance.Resource.DownloadNew}" Padding="13,7"
                                             Margin="0,7,15,0" HorizontalAlignment="Left" />
                             <local:MyButton x:Name="BtnManageSelectAll" MinWidth="110" Text="{DynamicResource Instance.Resource.SelectAll}" Padding="13,7"

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.cs
@@ -1051,7 +1051,7 @@ public partial class PageInstanceCompResource : IRefreshable
             .Select(instance =>
             {
                 var sourceFolder = Path.GetFullPath(Path.Combine(instance.PathIndie, folderName));
-                var files = GetImportFiles(instance, sourceFolder);
+                var files = _GetImportFiles(instance, sourceFolder);
                 return (Instance: instance, Folder: sourceFolder, Files: files);
             })
             .Where(source => !source.Folder.Equals(targetFolder, StringComparison.OrdinalIgnoreCase) &&
@@ -1079,7 +1079,7 @@ public partial class PageInstanceCompResource : IRefreshable
         InstallCompFiles(sources[selectedIndex.Value].Files, currentCompType, CurrentFolderPath);
     }
 
-    private static string[] GetImportFiles(McInstance instance, string sourceFolder)
+    private static string[] _GetImportFiles(McInstance instance, string sourceFolder)
     {
         try
         {

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.cs
@@ -1051,11 +1051,11 @@ public partial class PageInstanceCompResource : IRefreshable
             .Select(instance =>
             {
                 var sourceFolder = Path.GetFullPath(Path.Combine(instance.PathIndie, folderName));
-                var files = _GetImportFiles(instance, sourceFolder);
-                return (Instance: instance, Folder: sourceFolder, Files: files);
+                var entries = _GetImportEntries(instance, sourceFolder);
+                return (Instance: instance, Folder: sourceFolder, Entries: entries);
             })
             .Where(source => !source.Folder.Equals(targetFolder, StringComparison.OrdinalIgnoreCase) &&
-                             source.Files.Length > 0)
+                             source.Entries.Length > 0)
             .OrderBy(source => source.Instance.Name)
             .ToList();
 
@@ -1068,7 +1068,7 @@ public partial class PageInstanceCompResource : IRefreshable
         var selection = sources.Select(source => (IMyRadio)new MyListItem
         {
             Title = source.Instance.Name,
-            Info = Lang.Text("Instance.Resource.Import.FileCount", source.Files.Length),
+            Info = Lang.Text("Instance.Resource.Import.ItemCount", source.Entries.Length),
             Type = MyListItem.CheckType.RadioBox
         }).ToList();
         var selectedIndex = ModMain.MyMsgBoxSelect(selection,
@@ -1076,21 +1076,99 @@ public partial class PageInstanceCompResource : IRefreshable
             Lang.Text("Common.Action.Confirm"), Lang.Text("Common.Action.Cancel"));
         if (selectedIndex is null) return;
 
-        InstallCompFiles(sources[selectedIndex.Value].Files, currentCompType, CurrentFolderPath);
+        _ImportEntries(sources[selectedIndex.Value].Entries, targetFolder);
     }
 
-    private static string[] _GetImportFiles(McInstance instance, string sourceFolder)
+    private static string[] _GetImportEntries(McInstance instance, string sourceFolder)
     {
         try
         {
             return Directory.Exists(sourceFolder)
-                ? Directory.GetFiles(sourceFolder, "*.zip", SearchOption.TopDirectoryOnly)
+                ? Directory.EnumerateFileSystemEntries(sourceFolder, "*", new EnumerationOptions
+                {
+                    RecurseSubdirectories = false,
+                    IgnoreInaccessible = false,
+                    AttributesToSkip = FileAttributes.ReparsePoint
+                }).ToArray()
                 : [];
         }
         catch (Exception ex)
         {
             ModBase.Log(ex, $"读取实例 {instance.Name} 的资源文件失败");
             return [];
+        }
+    }
+
+    private void _ImportEntries(IEnumerable<string> entries, string targetFolder)
+    {
+        try
+        {
+            Directory.CreateDirectory(targetFolder);
+            var importedCount = 0;
+            foreach (var sourceEntry in entries)
+            {
+                var entryName = Path.GetFileName(Path.TrimEndingDirectorySeparator(sourceEntry));
+                var targetEntry = Path.Combine(targetFolder, entryName);
+                if (File.Exists(targetEntry) || Directory.Exists(targetEntry))
+                {
+                    if (ModMain.MyMsgBox(
+                            Lang.Text("Instance.Resource.Import.OverwriteConfirm.Message", entryName),
+                            Lang.Text("Instance.Resource.Import.OverwriteConfirm.Title"),
+                            Lang.Text("Common.Action.Overwrite"), Lang.Text("Common.Action.Cancel")) != 1)
+                        continue;
+                    _DeleteImportTarget(targetEntry);
+                }
+
+                if (File.Exists(sourceEntry))
+                    ModBase.CopyFile(sourceEntry, targetEntry);
+                else if (Directory.Exists(sourceEntry))
+                    _CopyImportDirectory(sourceEntry, targetEntry);
+                else
+                    continue;
+                importedCount += 1;
+            }
+
+            if (importedCount > 0)
+            {
+                HintService.Hint(Lang.Text("Instance.Resource.Import.Success", importedCount), HintType.Success);
+                ReloadCompFileList(true);
+            }
+        }
+        catch (Exception ex)
+        {
+            ModBase.Log(ex, "从其他实例复制资源失败", ModBase.LogLevel.Msgbox,
+                userSummary: Lang.Text("Instance.Resource.Error.OperationFailed"));
+        }
+    }
+
+    private static void _DeleteImportTarget(string targetEntry)
+    {
+        if (File.Exists(targetEntry))
+        {
+            File.Delete(targetEntry);
+            return;
+        }
+
+        if (!Directory.Exists(targetEntry)) return;
+        if (File.GetAttributes(targetEntry).HasFlag(FileAttributes.ReparsePoint))
+            Directory.Delete(targetEntry);
+        else
+            ModBase.DeleteDirectory(targetEntry);
+    }
+
+    private static void _CopyImportDirectory(string sourceFolder, string targetFolder)
+    {
+        Directory.CreateDirectory(targetFolder);
+        var options = new EnumerationOptions
+        {
+            RecurseSubdirectories = true,
+            IgnoreInaccessible = false,
+            AttributesToSkip = FileAttributes.ReparsePoint
+        };
+        foreach (var sourceFile in Directory.EnumerateFiles(sourceFolder, "*", options))
+        {
+            var targetFile = Path.Combine(targetFolder, Path.GetRelativePath(sourceFolder, sourceFile));
+            ModBase.CopyFile(sourceFile, targetFile);
         }
     }
 

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.cs
@@ -42,6 +42,7 @@ public partial class PageInstanceCompResource : IRefreshable
         BtnManageInstall.Click += BtnManageInstall_Click;
         BtnManageImport.Click += BtnManageImport_Click;
         BtnHintInstall.Click += BtnManageInstall_Click;
+        BtnHintImport.Click += BtnManageImport_Click;
         BtnManageInfoExport.Click += BtnManageInfoExport_Click;
         BtnManageDownload.Click += BtnManageDownload_Click;
         BtnHintDownload.Click += BtnManageDownload_Click;
@@ -119,7 +120,10 @@ public partial class PageInstanceCompResource : IRefreshable
         }
 
         if (new[] { ModComp.CompType.Shader, ModComp.CompType.ResourcePack }.Contains(currentCompType))
+        {
             BtnManageImport.Visibility = Visibility.Visible;
+            BtnHintImport.Visibility = Visibility.Visible;
+        }
 
         // 投影文件管理页隐藏下载按钮
         if (currentCompType == ModComp.CompType.Schematic)
@@ -142,6 +146,7 @@ public partial class PageInstanceCompResource : IRefreshable
         BtnManageInstall.Click += BtnManageInstall_Click;
         BtnManageImport.Click += BtnManageImport_Click;
         BtnHintInstall.Click += BtnManageInstall_Click;
+        BtnHintImport.Click += BtnManageImport_Click;
         BtnManageDownload.Click += BtnManageDownload_Click;
         BtnHintDownload.Click += BtnManageDownload_Click;
         BtnManageInfoExport.Click += BtnManageInfoExport_Click;
@@ -1046,9 +1051,7 @@ public partial class PageInstanceCompResource : IRefreshable
             .Select(instance =>
             {
                 var sourceFolder = Path.GetFullPath(Path.Combine(instance.PathIndie, folderName));
-                var files = Directory.Exists(sourceFolder)
-                    ? Directory.GetFiles(sourceFolder, "*.zip", SearchOption.TopDirectoryOnly)
-                    : [];
+                var files = GetImportFiles(instance, sourceFolder);
                 return (Instance: instance, Folder: sourceFolder, Files: files);
             })
             .Where(source => !source.Folder.Equals(targetFolder, StringComparison.OrdinalIgnoreCase) &&
@@ -1074,6 +1077,21 @@ public partial class PageInstanceCompResource : IRefreshable
         if (selectedIndex is null) return;
 
         InstallCompFiles(sources[selectedIndex.Value].Files, currentCompType, CurrentFolderPath);
+    }
+
+    private static string[] GetImportFiles(McInstance instance, string sourceFolder)
+    {
+        try
+        {
+            return Directory.Exists(sourceFolder)
+                ? Directory.GetFiles(sourceFolder, "*.zip", SearchOption.TopDirectoryOnly)
+                : [];
+        }
+        catch (Exception ex)
+        {
+            ModBase.Log(ex, $"读取实例 {instance.Name} 的资源文件失败");
+            return [];
+        }
     }
 
     /// <summary>

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.cs
@@ -40,6 +40,7 @@ public partial class PageInstanceCompResource : IRefreshable
         BtnHintOpen.Click += BtnManageOpen_Click;
         BtnManageSelectAll.Click += BtnManageSelectAll_Click;
         BtnManageInstall.Click += BtnManageInstall_Click;
+        BtnManageImport.Click += BtnManageImport_Click;
         BtnHintInstall.Click += BtnManageInstall_Click;
         BtnManageInfoExport.Click += BtnManageInfoExport_Click;
         BtnManageDownload.Click += BtnManageDownload_Click;
@@ -117,6 +118,9 @@ public partial class PageInstanceCompResource : IRefreshable
             BtnSelectDisable.Visibility = Visibility.Collapsed;
         }
 
+        if (new[] { ModComp.CompType.Shader, ModComp.CompType.ResourcePack }.Contains(currentCompType))
+            BtnManageImport.Visibility = Visibility.Visible;
+
         // 投影文件管理页隐藏下载按钮
         if (currentCompType == ModComp.CompType.Schematic)
         {
@@ -136,6 +140,7 @@ public partial class PageInstanceCompResource : IRefreshable
         BtnHintOpen.Click += BtnManageOpen_Click;
         BtnManageSelectAll.Click += BtnManageSelectAll_Click;
         BtnManageInstall.Click += BtnManageInstall_Click;
+        BtnManageImport.Click += BtnManageImport_Click;
         BtnHintInstall.Click += BtnManageInstall_Click;
         BtnManageDownload.Click += BtnManageDownload_Click;
         BtnHintDownload.Click += BtnManageDownload_Click;
@@ -1019,6 +1024,56 @@ public partial class PageInstanceCompResource : IRefreshable
         if (fileList is null || !fileList.Any())
             return;
         InstallCompFiles(fileList, currentCompType, CurrentFolderPath);
+    }
+
+    /// <summary>
+    ///     从其他实例导入资源包或光影包。
+    /// </summary>
+    private void BtnManageImport_Click(object sender, MouseButtonEventArgs e)
+    {
+        var folderName = currentCompType switch
+        {
+            ModComp.CompType.ResourcePack => "resourcepacks",
+            ModComp.CompType.Shader => "shaderpacks",
+            _ => null
+        };
+        if (folderName is null) return;
+
+        var targetFolder = Path.GetFullPath(Path.Combine(PageInstanceLeft.McInstance.PathIndie, folderName));
+        var sources = ModInstanceList.mcInstanceList.Values.SelectMany(list => list)
+            .Where(instance => instance.state != McInstanceState.Error &&
+                               !instance.Equals(PageInstanceLeft.McInstance))
+            .Select(instance =>
+            {
+                var sourceFolder = Path.GetFullPath(Path.Combine(instance.PathIndie, folderName));
+                var files = Directory.Exists(sourceFolder)
+                    ? Directory.GetFiles(sourceFolder, "*.zip", SearchOption.TopDirectoryOnly)
+                    : [];
+                return (Instance: instance, Folder: sourceFolder, Files: files);
+            })
+            .Where(source => !source.Folder.Equals(targetFolder, StringComparison.OrdinalIgnoreCase) &&
+                             source.Files.Length > 0)
+            .OrderBy(source => source.Instance.Name)
+            .ToList();
+
+        if (sources.Count == 0)
+        {
+            HintService.Hint(Lang.Text("Instance.Resource.Import.NoAvailableInstance"));
+            return;
+        }
+
+        var selection = sources.Select(source => (IMyRadio)new MyListItem
+        {
+            Title = source.Instance.Name,
+            Info = Lang.Text("Instance.Resource.Import.FileCount", source.Files.Length),
+            Type = MyListItem.CheckType.RadioBox
+        }).ToList();
+        var selectedIndex = ModMain.MyMsgBoxSelect(selection,
+            Lang.Text("Instance.Resource.Import.SelectInstance"),
+            Lang.Text("Common.Action.Confirm"), Lang.Text("Common.Action.Cancel"));
+        if (selectedIndex is null) return;
+
+        InstallCompFiles(sources[selectedIndex.Value].Files, currentCompType, CurrentFolderPath);
     }
 
     /// <summary>


### PR DESCRIPTION
## 修改内容

- 在资源包与光影包管理页增加“从其他实例导入”入口，并覆盖有内容与空列表两种页面状态
- 列出资源目录中存在文件或文件夹的其他实例，排除当前实例与共用同一目标目录的实例
- 将来源目录中的顶层文件和文件夹直接复制到目标实例；ZIP 作为普通文件原样复制，文件夹资源递归复制
- 同名文件或文件夹逐项确认覆盖，完成后刷新资源列表；复制时跳过重解析点

## 验证情况

- `dotnet build "Plain Craft Launcher 2/Plain Craft Launcher 2.csproj" -c Debug -p:Platform=x64 --no-restore`：通过，0 个错误
- 仓库外临时验证程序：ZIP、普通文件和文件夹枚举，文件夹递归复制、覆盖目标清理与缺失来源目录均通过
- `git diff --check dev...feat/import-from-other-instance`：通过

## AI 使用

- GPT-5.6：辅助实现、代码审查与本地验证
- 仓库内未新增文档或测试文件

## Summary by Sourcery

为资源包和光影包管理增加跨实例导入能力。

New Features:
- 为资源包和光影包管理页增加从其他实例导入资源的入口。

Enhancements:
- 支持选择可用的其他实例，并将其顶层资源文件或文件夹导入当前实例。
- 支持导入过程中的同名资源覆盖确认、递归复制及完成后的列表刷新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为资源包和光影包管理增加跨实例导入能力。

New Features:
- 为资源包和光影包管理页增加从其他实例导入资源的入口。

Enhancements:
- 支持选择可用的其他实例，并将其顶层资源文件或文件夹导入当前实例。
- 支持导入过程中的同名资源覆盖确认、递归复制及完成后的列表刷新。

</details>