### PR TITLE
feat(instance): 删除实例前备份截图与投影原理图 [GPT-5.6]

### DIFF
--- a/PCL.Core/App/Config.cs
+++ b/PCL.Core/App/Config.cs
@@ -566,6 +566,11 @@ public static partial class Config
         [ConfigItem<int>("LaunchArgumentIndieV2", 4, ConfigSource.Local)] public partial int IndieSolutionV2 { get; set; }
 
         /// <summary>
+        /// 删除隔离实例前备份截图与投影原理图。
+        /// </summary>
+        [ConfigItem<bool>("LaunchArgumentPreservePersonalFiles", true, ConfigSource.Local)] public partial bool PreservePersonalFiles { get; set; }
+
+        /// <summary>
         /// 游戏启动后启动器可见性。
         /// </summary>
         [ConfigItem<LauncherVisibility>("LaunchArgumentVisible", LauncherVisibility.DoNothing)] public partial LauncherVisibility LauncherVisibility { get; set; }

--- a/PCL.Core/App/Config.cs
+++ b/PCL.Core/App/Config.cs
@@ -566,9 +566,9 @@ public static partial class Config
         [ConfigItem<int>("LaunchArgumentIndieV2", 4, ConfigSource.Local)] public partial int IndieSolutionV2 { get; set; }
 
         /// <summary>
-        /// 删除隔离实例前备份截图与投影原理图。
+        /// 删除隔离实例前的个人文件备份模式。
         /// </summary>
-        [ConfigItem<bool>("LaunchArgumentPreservePersonalFiles", true, ConfigSource.Local)] public partial bool PreservePersonalFiles { get; set; }
+        [ConfigItem<PersonalFilesBackupMode>("LaunchArgumentPersonalFilesBackupMode", PersonalFilesBackupMode.AskEveryTime, ConfigSource.Local)] public partial PersonalFilesBackupMode PersonalFilesBackup { get; set; }
 
         /// <summary>
         /// 游戏启动后启动器可见性。

--- a/PCL.Core/App/ConfigEnums.cs
+++ b/PCL.Core/App/ConfigEnums.cs
@@ -65,6 +65,16 @@ public enum GameProcessPriority
 }
 
 /// <summary>
+/// 删除实例时的个人文件备份模式。
+/// </summary>
+public enum PersonalFilesBackupMode
+{
+    Disabled = 0,
+    AskEveryTime = 1,
+    Always = 2
+}
+
+/// <summary>
 /// 游戏启动后启动器可见性
 /// </summary>
 public enum LauncherVisibility

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -977,6 +977,11 @@
     <sys:String x:Key="Instance.Overall.Shortcuts.SavesFolder">Saves folder</sys:String>
     <sys:String x:Key="Instance.Overall.Shortcuts.Title">Shortcuts</sys:String>
     <sys:String x:Key="Instance.Overall.Unfavorite">Unfavorite</sys:String>
+    <sys:String x:Key="Instance.PersonalFiles.Backup.Ask.BackupAndDelete">Back up and delete</sys:String>
+    <sys:String x:Key="Instance.PersonalFiles.Backup.Ask.DeleteWithoutBackup">Delete without backup</sys:String>
+    <sys:String x:Key="Instance.PersonalFiles.Backup.Ask.Message">Screenshots were found in instance {0}. Back them up before deletion?&#xA;Schematics will be backed up at the same time.</sys:String>
+    <sys:String x:Key="Instance.PersonalFiles.Backup.Ask.Title">Back up screenshots</sys:String>
+    <sys:String x:Key="Instance.PersonalFiles.Backup.AskHint">When screenshots are found, you will be asked whether to back them up before deletion.</sys:String>
     <sys:String x:Key="Instance.PersonalFiles.Backup.DeleteHint">Files will be backed up to a folder before deletion.</sys:String>
     <sys:String x:Key="Instance.PersonalFiles.Backup.Failed">Failed to back up screenshots or schematics. The instance was kept. See the error details.</sys:String>
     <sys:String x:Key="Instance.PersonalFiles.Backup.Success">Backed up {0} personal file(s) to: {1}</sys:String>
@@ -2820,8 +2825,10 @@
     <sys:String x:Key="Setup.Launch.Options.InstanceIsolation.NonRelease.ToolTip">Isolate snapshots, pre-releases, old versions, and April Fools' versions from other instances.</sys:String>
     <sys:String x:Key="Setup.Launch.Options.InstanceIsolation.None.ToolTip">All instances use the same profile. Saves, mods, resource packs, and other files are shared.&#xA;If multiple instances with mods installed are present, this may cause mod conflicts.</sys:String>
     <sys:String x:Key="Setup.Launch.Options.InstanceIsolation.ToolTip">When installing a new instance, the isolation option for the new instance will be automatically set accordingly.&#xA;To adjust the isolation policy for an existing instance, please go to instance settings.</sys:String>
-    <sys:String x:Key="Setup.Launch.Options.PersonalFilesBackup">Back up screenshots and schematics when deleting isolated instances</sys:String>
-    <sys:String x:Key="Setup.Launch.Options.PersonalFilesBackup.ToolTip">Before deleting an instance, copy its screenshots and schematics folders to PCL\PersonalFiles in the current Minecraft folder. Deletion is canceled if the backup fails.</sys:String>
+    <sys:String x:Key="Setup.Launch.Options.PersonalFilesBackup">Protect screenshots when deleting isolated instances</sys:String>
+    <sys:String x:Key="Setup.Launch.Options.PersonalFilesBackup.Always">Always back up</sys:String>
+    <sys:String x:Key="Setup.Launch.Options.PersonalFilesBackup.AskEveryTime">Ask every time</sys:String>
+    <sys:String x:Key="Setup.Launch.Options.PersonalFilesBackup.ToolTip">Backups are saved to PCL\PersonalFiles in the current Minecraft folder. Schematics are included when screenshots are backed up. Deletion is canceled if the backup fails.</sys:String>
 
     <!-- Setup.Launch.Options.Visibility -->
 

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -977,7 +977,7 @@
     <sys:String x:Key="Instance.Overall.Shortcuts.SavesFolder">Saves folder</sys:String>
     <sys:String x:Key="Instance.Overall.Shortcuts.Title">Shortcuts</sys:String>
     <sys:String x:Key="Instance.Overall.Unfavorite">Unfavorite</sys:String>
-    <sys:String x:Key="Instance.PersonalFiles.Backup.DeleteHint">Screenshots and schematics will be backed up to PCL\PersonalFiles before deletion. Deletion is canceled if the backup fails.</sys:String>
+    <sys:String x:Key="Instance.PersonalFiles.Backup.DeleteHint">Files will be backed up to a folder before deletion.</sys:String>
     <sys:String x:Key="Instance.PersonalFiles.Backup.Failed">Failed to back up screenshots or schematics. The instance was kept. See the error details.</sys:String>
     <sys:String x:Key="Instance.PersonalFiles.Backup.Success">Backed up {0} personal file(s) to: {1}</sys:String>
 

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -977,6 +977,9 @@
     <sys:String x:Key="Instance.Overall.Shortcuts.SavesFolder">Saves folder</sys:String>
     <sys:String x:Key="Instance.Overall.Shortcuts.Title">Shortcuts</sys:String>
     <sys:String x:Key="Instance.Overall.Unfavorite">Unfavorite</sys:String>
+    <sys:String x:Key="Instance.PersonalFiles.Backup.DeleteHint">Screenshots and schematics will be backed up to PCL\PersonalFiles before deletion. Deletion is canceled if the backup fails.</sys:String>
+    <sys:String x:Key="Instance.PersonalFiles.Backup.Failed">Failed to back up screenshots or schematics. The instance was kept. See the error details.</sys:String>
+    <sys:String x:Key="Instance.PersonalFiles.Backup.Success">Backed up {0} personal file(s) to: {1}</sys:String>
 
     <!-- Instance.Overall.Icon -->
 

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -2817,6 +2817,8 @@
     <sys:String x:Key="Setup.Launch.Options.InstanceIsolation.NonRelease.ToolTip">Isolate snapshots, pre-releases, old versions, and April Fools' versions from other instances.</sys:String>
     <sys:String x:Key="Setup.Launch.Options.InstanceIsolation.None.ToolTip">All instances use the same profile. Saves, mods, resource packs, and other files are shared.&#xA;If multiple instances with mods installed are present, this may cause mod conflicts.</sys:String>
     <sys:String x:Key="Setup.Launch.Options.InstanceIsolation.ToolTip">When installing a new instance, the isolation option for the new instance will be automatically set accordingly.&#xA;To adjust the isolation policy for an existing instance, please go to instance settings.</sys:String>
+    <sys:String x:Key="Setup.Launch.Options.PersonalFilesBackup">Back up screenshots and schematics when deleting isolated instances</sys:String>
+    <sys:String x:Key="Setup.Launch.Options.PersonalFilesBackup.ToolTip">Before deleting an instance, copy its screenshots and schematics folders to PCL\PersonalFiles in the current Minecraft folder. Deletion is canceled if the backup fails.</sys:String>
 
     <!-- Setup.Launch.Options.Visibility -->
 

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -977,6 +977,9 @@
     <sys:String x:Key="Instance.Overall.Shortcuts.SavesFolder">存档文件夹</sys:String>
     <sys:String x:Key="Instance.Overall.Shortcuts.Title">快捷方式</sys:String>
     <sys:String x:Key="Instance.Overall.Unfavorite">从收藏夹中移除</sys:String>
+    <sys:String x:Key="Instance.PersonalFiles.Backup.DeleteHint">删除前会将截图与投影原理图备份到 PCL\PersonalFiles；备份失败时会取消删除。</sys:String>
+    <sys:String x:Key="Instance.PersonalFiles.Backup.Failed">备份截图或投影原理图失败，实例未删除。请查看错误详情。</sys:String>
+    <sys:String x:Key="Instance.PersonalFiles.Backup.Success">已将 {0} 个回忆文件备份到：{1}</sys:String>
 
     <!-- Instance.Overall.Icon -->
 

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -977,6 +977,11 @@
     <sys:String x:Key="Instance.Overall.Shortcuts.SavesFolder">存档文件夹</sys:String>
     <sys:String x:Key="Instance.Overall.Shortcuts.Title">快捷方式</sys:String>
     <sys:String x:Key="Instance.Overall.Unfavorite">从收藏夹中移除</sys:String>
+    <sys:String x:Key="Instance.PersonalFiles.Backup.Ask.BackupAndDelete">备份并删除</sys:String>
+    <sys:String x:Key="Instance.PersonalFiles.Backup.Ask.DeleteWithoutBackup">直接删除</sys:String>
+    <sys:String x:Key="Instance.PersonalFiles.Backup.Ask.Message">检测到实例 {0} 中有截图，是否在删除前备份？&#xA;投影原理图也会一并备份。</sys:String>
+    <sys:String x:Key="Instance.PersonalFiles.Backup.Ask.Title">备份截图</sys:String>
+    <sys:String x:Key="Instance.PersonalFiles.Backup.AskHint">检测到截图时，删除前会询问是否备份。</sys:String>
     <sys:String x:Key="Instance.PersonalFiles.Backup.DeleteHint">删除前会备份文件到文件夹。</sys:String>
     <sys:String x:Key="Instance.PersonalFiles.Backup.Failed">备份截图或投影原理图失败，实例未删除。请查看错误详情。</sys:String>
     <sys:String x:Key="Instance.PersonalFiles.Backup.Success">已将 {0} 个回忆文件备份到：{1}</sys:String>
@@ -2820,8 +2825,10 @@
     <sys:String x:Key="Setup.Launch.Options.InstanceIsolation.NonRelease.ToolTip">将 Minecraft 快照、预发布版、远古版本、愚人节版本与其他实例进行隔离</sys:String>
     <sys:String x:Key="Setup.Launch.Options.InstanceIsolation.None.ToolTip">所有实例均使用同一档案，存档、模组、资源包等均为公用。&#xA;若存在多个安装了模组的实例，可能会导致模组冲突。</sys:String>
     <sys:String x:Key="Setup.Launch.Options.InstanceIsolation.ToolTip">当安装新实例时，据此自动设置新实例的隔离选项。&#xA;若想调整已有实例的隔离策略，请前往它的实例设置。</sys:String>
-    <sys:String x:Key="Setup.Launch.Options.PersonalFilesBackup">删除隔离实例时备份截图与投影原理图</sys:String>
-    <sys:String x:Key="Setup.Launch.Options.PersonalFilesBackup.ToolTip">删除实例前，将 screenshots 与 schematics 文件夹复制到当前 Minecraft 文件夹下的 PCL\PersonalFiles。备份失败时会取消删除。</sys:String>
+    <sys:String x:Key="Setup.Launch.Options.PersonalFilesBackup">删除隔离实例时保护截图</sys:String>
+    <sys:String x:Key="Setup.Launch.Options.PersonalFilesBackup.Always">始终备份</sys:String>
+    <sys:String x:Key="Setup.Launch.Options.PersonalFilesBackup.AskEveryTime">每次询问</sys:String>
+    <sys:String x:Key="Setup.Launch.Options.PersonalFilesBackup.ToolTip">备份文件会保存到当前 Minecraft 文件夹下的 PCL\PersonalFiles。备份截图时也会保存投影原理图；备份失败时会取消删除。</sys:String>
 
     <!-- Setup.Launch.Options.Visibility -->
 

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -2817,6 +2817,8 @@
     <sys:String x:Key="Setup.Launch.Options.InstanceIsolation.NonRelease.ToolTip">将 Minecraft 快照、预发布版、远古版本、愚人节版本与其他实例进行隔离</sys:String>
     <sys:String x:Key="Setup.Launch.Options.InstanceIsolation.None.ToolTip">所有实例均使用同一档案，存档、模组、资源包等均为公用。&#xA;若存在多个安装了模组的实例，可能会导致模组冲突。</sys:String>
     <sys:String x:Key="Setup.Launch.Options.InstanceIsolation.ToolTip">当安装新实例时，据此自动设置新实例的隔离选项。&#xA;若想调整已有实例的隔离策略，请前往它的实例设置。</sys:String>
+    <sys:String x:Key="Setup.Launch.Options.PersonalFilesBackup">删除隔离实例时备份截图与投影原理图</sys:String>
+    <sys:String x:Key="Setup.Launch.Options.PersonalFilesBackup.ToolTip">删除实例前，将 screenshots 与 schematics 文件夹复制到当前 Minecraft 文件夹下的 PCL\PersonalFiles。备份失败时会取消删除。</sys:String>
 
     <!-- Setup.Launch.Options.Visibility -->
 

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -977,7 +977,7 @@
     <sys:String x:Key="Instance.Overall.Shortcuts.SavesFolder">存档文件夹</sys:String>
     <sys:String x:Key="Instance.Overall.Shortcuts.Title">快捷方式</sys:String>
     <sys:String x:Key="Instance.Overall.Unfavorite">从收藏夹中移除</sys:String>
-    <sys:String x:Key="Instance.PersonalFiles.Backup.DeleteHint">删除前会将截图与投影原理图备份到 PCL\PersonalFiles；备份失败时会取消删除。</sys:String>
+    <sys:String x:Key="Instance.PersonalFiles.Backup.DeleteHint">删除前会备份文件到文件夹。</sys:String>
     <sys:String x:Key="Instance.PersonalFiles.Backup.Failed">备份截图或投影原理图失败，实例未删除。请查看错误详情。</sys:String>
     <sys:String x:Key="Instance.PersonalFiles.Backup.Success">已将 {0} 个回忆文件备份到：{1}</sys:String>
 

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModPersonalFiles.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModPersonalFiles.cs
@@ -6,25 +6,21 @@ namespace PCL;
 
 public static class ModPersonalFiles
 {
-    public static string ArchiveRoot =>
+    private static string _ArchiveRoot =>
         Path.GetFullPath(Path.Combine(ModFolder.mcFolderSelected, "PCL", "PersonalFiles"));
 
-    public static (int FileCount, string TargetFolder) Backup(McInstance instance,
-        bool includeScreenshots = true, bool includeSchematics = true)
+    private static (int FileCount, string TargetFolder) _Backup(McInstance instance)
     {
-        var targetFolder = Path.Combine(ArchiveRoot, instance.Name);
+        var targetFolder = Path.Combine(_ArchiveRoot, instance.Name);
         var instancePath = Path.GetFullPath(instance.PathInstance);
         if (!instancePath.EndsWith(Path.DirectorySeparatorChar)) instancePath += Path.DirectorySeparatorChar;
         if (targetFolder.StartsWith(instancePath, StringComparison.OrdinalIgnoreCase))
             throw new InvalidOperationException("回忆文件备份目录不能位于实例目录中");
 
-        var fileCount = 0;
-        if (includeScreenshots)
-            fileCount += _CopyDirectory(Path.Combine(instance.PathIndie, "screenshots"),
-                Path.Combine(targetFolder, "screenshots"));
-        if (includeSchematics)
-            fileCount += _CopyDirectory(Path.Combine(instance.PathIndie, "schematics"),
-                Path.Combine(targetFolder, "schematics"));
+        var fileCount = _CopyDirectory(Path.Combine(instance.PathIndie, "screenshots"),
+            Path.Combine(targetFolder, "screenshots"));
+        fileCount += _CopyDirectory(Path.Combine(instance.PathIndie, "schematics"),
+            Path.Combine(targetFolder, "schematics"));
 
         if (fileCount > 0)
             ModBase.Log($"[PersonalFiles] 已备份实例 {instance.Name} 的 {fileCount} 个回忆文件到 {targetFolder}");
@@ -35,7 +31,7 @@ public static class ModPersonalFiles
     {
         try
         {
-            var result = Backup(instance);
+            var result = _Backup(instance);
             if (result.FileCount > 0)
                 HintService.Hint(Lang.Text("Instance.PersonalFiles.Backup.Success", result.FileCount,
                     result.TargetFolder), HintType.Success);

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModPersonalFiles.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModPersonalFiles.cs
@@ -1,0 +1,73 @@
+using System.IO;
+using PCL.Core.App.Localization;
+using PCL.Core.UI;
+
+namespace PCL;
+
+public static class ModPersonalFiles
+{
+    public static string ArchiveRoot =>
+        Path.GetFullPath(Path.Combine(ModFolder.mcFolderSelected, "PCL", "PersonalFiles"));
+
+    public static (int FileCount, string TargetFolder) Backup(McInstance instance,
+        bool includeScreenshots = true, bool includeSchematics = true)
+    {
+        var targetFolder = Path.Combine(ArchiveRoot, instance.Name);
+        var instancePath = Path.GetFullPath(instance.PathInstance);
+        if (!instancePath.EndsWith(Path.DirectorySeparatorChar)) instancePath += Path.DirectorySeparatorChar;
+        if (targetFolder.StartsWith(instancePath, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException("回忆文件备份目录不能位于实例目录中");
+
+        var fileCount = 0;
+        if (includeScreenshots)
+            fileCount += _CopyDirectory(Path.Combine(instance.PathIndie, "screenshots"),
+                Path.Combine(targetFolder, "screenshots"));
+        if (includeSchematics)
+            fileCount += _CopyDirectory(Path.Combine(instance.PathIndie, "schematics"),
+                Path.Combine(targetFolder, "schematics"));
+
+        if (fileCount > 0)
+            ModBase.Log($"[PersonalFiles] 已备份实例 {instance.Name} 的 {fileCount} 个回忆文件到 {targetFolder}");
+        return (fileCount, targetFolder);
+    }
+
+    public static bool TryBackupBeforeDelete(McInstance instance)
+    {
+        try
+        {
+            var result = Backup(instance);
+            if (result.FileCount > 0)
+                HintService.Hint(Lang.Text("Instance.PersonalFiles.Backup.Success", result.FileCount,
+                    result.TargetFolder), HintType.Success);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            ModBase.Log(ex, $"备份实例 {instance.Name} 的回忆文件失败", ModBase.LogLevel.Msgbox,
+                userSummary: Lang.Text("Instance.PersonalFiles.Backup.Failed"));
+            return false;
+        }
+    }
+
+    private static int _CopyDirectory(string sourceFolder, string targetFolder)
+    {
+        if (!Directory.Exists(sourceFolder)) return 0;
+        var options = new EnumerationOptions
+        {
+            RecurseSubdirectories = true,
+            IgnoreInaccessible = false,
+            AttributesToSkip = FileAttributes.ReparsePoint
+        };
+        var fileCount = 0;
+        foreach (var sourceFile in Directory.EnumerateFiles(sourceFolder, "*", options))
+        {
+            var targetFile = Path.Combine(targetFolder, Path.GetRelativePath(sourceFolder, sourceFile));
+            ModBase.CopyFile(sourceFile, targetFile);
+            File.SetCreationTimeUtc(targetFile, File.GetCreationTimeUtc(sourceFile));
+            File.SetLastWriteTimeUtc(targetFile, File.GetLastWriteTimeUtc(sourceFile));
+            fileCount += 1;
+        }
+
+        return fileCount;
+    }
+}

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModPersonalFiles.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModPersonalFiles.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using PCL.Core.App;
 using PCL.Core.App.Localization;
 using PCL.Core.UI;
 
@@ -27,10 +28,35 @@ public static class ModPersonalFiles
         return (fileCount, targetFolder);
     }
 
-    public static bool TryBackupBeforeDelete(McInstance instance)
+    public static string? GetDeleteHint()
+    {
+        return Config.Launch.PersonalFilesBackup switch
+        {
+            PersonalFilesBackupMode.Disabled => null,
+            PersonalFilesBackupMode.AskEveryTime => Lang.Text("Instance.PersonalFiles.Backup.AskHint"),
+            _ => Lang.Text("Instance.PersonalFiles.Backup.DeleteHint")
+        };
+    }
+
+    public static bool TryHandleBeforeDelete(McInstance instance)
     {
         try
         {
+            var backupMode = Config.Launch.PersonalFilesBackup;
+            if (backupMode == PersonalFilesBackupMode.Disabled) return true;
+            if (backupMode == PersonalFilesBackupMode.AskEveryTime)
+            {
+                if (!_HasScreenshots(instance.PathIndie)) return true;
+                var promptResult = ModMain.MyMsgBox(
+                    Lang.Text("Instance.PersonalFiles.Backup.Ask.Message", instance.Name),
+                    Lang.Text("Instance.PersonalFiles.Backup.Ask.Title"),
+                    Lang.Text("Instance.PersonalFiles.Backup.Ask.BackupAndDelete"),
+                    Lang.Text("Instance.PersonalFiles.Backup.Ask.DeleteWithoutBackup"),
+                    Lang.Text("Common.Action.Cancel"));
+                if (promptResult == 2) return true;
+                if (promptResult != 1) return false;
+            }
+
             var result = _Backup(instance);
             if (result.FileCount > 0)
                 HintService.Hint(Lang.Text("Instance.PersonalFiles.Backup.Success", result.FileCount,
@@ -45,17 +71,18 @@ public static class ModPersonalFiles
         }
     }
 
+    private static bool _HasScreenshots(string instanceFolder)
+    {
+        var screenshotFolder = Path.Combine(instanceFolder, "screenshots");
+        return Directory.Exists(screenshotFolder) &&
+               Directory.EnumerateFiles(screenshotFolder, "*", _CreateEnumerationOptions()).Any();
+    }
+
     private static int _CopyDirectory(string sourceFolder, string targetFolder)
     {
         if (!Directory.Exists(sourceFolder)) return 0;
-        var options = new EnumerationOptions
-        {
-            RecurseSubdirectories = true,
-            IgnoreInaccessible = false,
-            AttributesToSkip = FileAttributes.ReparsePoint
-        };
         var fileCount = 0;
-        foreach (var sourceFile in Directory.EnumerateFiles(sourceFolder, "*", options))
+        foreach (var sourceFile in Directory.EnumerateFiles(sourceFolder, "*", _CreateEnumerationOptions()))
         {
             var targetFile = Path.Combine(targetFolder, Path.GetRelativePath(sourceFolder, sourceFile));
             ModBase.CopyFile(sourceFile, targetFile);
@@ -65,5 +92,15 @@ public static class ModPersonalFiles
         }
 
         return fileCount;
+    }
+
+    private static EnumerationOptions _CreateEnumerationOptions()
+    {
+        return new EnumerationOptions
+        {
+            RecurseSubdirectories = true,
+            IgnoreInaccessible = false,
+            AttributesToSkip = FileAttributes.ReparsePoint
+        };
     }
 }

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceOverall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceOverall.xaml.cs
@@ -751,9 +751,12 @@ public partial class PageInstanceOverall
                 (false, true) => "Instance.Overall.Delete.ConfirmMessagePermanent",
                 (false, false) => "Instance.Overall.Delete.ConfirmMessage"
             };
+            var confirmMessage = Lang.Text(confirmMessageKey, PageInstanceLeft.McInstance.Name);
+            if (isIsolatedInstance && Config.Launch.PreservePersonalFiles)
+                confirmMessage += "\r\n" + Lang.Text("Instance.PersonalFiles.Backup.DeleteHint");
 
             var confirmResult = ModMain.MyMsgBox(
-                Lang.Text(confirmMessageKey, PageInstanceLeft.McInstance.Name),
+                confirmMessage,
                 Lang.Text("Instance.Overall.Delete.ConfirmTitle"),
                 button2: Lang.Text("Common.Action.Cancel"),
                 isWarn: isIsolatedInstance || isShiftPressed
@@ -763,6 +766,8 @@ public partial class PageInstanceOverall
             {
                 case 1:
                 {
+                    if (isIsolatedInstance && Config.Launch.PreservePersonalFiles &&
+                        !ModPersonalFiles.TryBackupBeforeDelete(PageInstanceLeft.McInstance)) return;
                     var instancePath = PageInstanceLeft.McInstance.PathInstance;
                     var instanceName = PageInstanceLeft.McInstance.Name;
                     ModBase.IniClearCache(Path.Combine(PageInstanceLeft.McInstance.PathIndie, "options.txt"));

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceOverall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceOverall.xaml.cs
@@ -752,8 +752,8 @@ public partial class PageInstanceOverall
                 (false, false) => "Instance.Overall.Delete.ConfirmMessage"
             };
             var confirmMessage = Lang.Text(confirmMessageKey, PageInstanceLeft.McInstance.Name);
-            if (isIsolatedInstance && Config.Launch.PreservePersonalFiles)
-                confirmMessage += "\r\n" + Lang.Text("Instance.PersonalFiles.Backup.DeleteHint");
+            var backupHint = isIsolatedInstance ? ModPersonalFiles.GetDeleteHint() : null;
+            if (backupHint is not null) confirmMessage += "\r\n" + backupHint;
 
             var confirmResult = ModMain.MyMsgBox(
                 confirmMessage,
@@ -766,8 +766,8 @@ public partial class PageInstanceOverall
             {
                 case 1:
                 {
-                    if (isIsolatedInstance && Config.Launch.PreservePersonalFiles &&
-                        !ModPersonalFiles.TryBackupBeforeDelete(PageInstanceLeft.McInstance)) return;
+                    if (isIsolatedInstance &&
+                        !ModPersonalFiles.TryHandleBeforeDelete(PageInstanceLeft.McInstance)) return;
                     var instancePath = PageInstanceLeft.McInstance.PathInstance;
                     var instanceName = PageInstanceLeft.McInstance.Name;
                     ModBase.IniClearCache(Path.Combine(PageInstanceLeft.McInstance.PathIndie, "options.txt"));

--- a/Plain Craft Launcher 2/Pages/PageSelectRight.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSelectRight.xaml.cs
@@ -537,12 +537,16 @@ public partial class PageSelectRight
                 ? Lang.Text("Select.Instance.Delete.ConfirmPermanentMessage", mcInstance.Name)
                 : Lang.Text("Select.Instance.Delete.ConfirmMessage", mcInstance.Name);
             var confirmFullMsg = confirmMsg +
-                                 (isHintIndie ? "\r\n" + Lang.Text("Select.Instance.Delete.IsolatedWarning") : "");
+                                  (isHintIndie ? "\r\n" + Lang.Text("Select.Instance.Delete.IsolatedWarning") : "");
+            if (isHintIndie && Config.Launch.PreservePersonalFiles)
+                confirmFullMsg += "\r\n" + Lang.Text("Instance.PersonalFiles.Backup.DeleteHint");
             switch (ModMain.MyMsgBox(confirmFullMsg, Lang.Text("Select.Instance.Delete.ConfirmTitle"),
                         button2: Lang.Text("Common.Action.Cancel"), isWarn: true))
             {
                 case 1:
                 {
+                    if (isHintIndie && Config.Launch.PreservePersonalFiles &&
+                        !ModPersonalFiles.TryBackupBeforeDelete(mcInstance)) return;
                     ModBase.IniClearCache(Path.Combine(mcInstance.PathIndie, "options.txt"));
                     ((DynamicCacheConfigStorage)ConfigService.GetProvider(ConfigSource.GameInstance)).InvalidateCache(
                         mcInstance.PathInstance);

--- a/Plain Craft Launcher 2/Pages/PageSelectRight.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSelectRight.xaml.cs
@@ -532,7 +532,8 @@ public partial class PageSelectRight
         {
             var isShiftPressed = Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift);
             var isHintIndie = mcInstance.state != McInstanceState.Error &&
-                              (mcInstance.PathIndie ?? "") != (ModFolder.mcFolderSelected ?? "");
+                              !string.Equals(mcInstance.PathIndie, ModFolder.mcFolderSelected,
+                                  StringComparison.OrdinalIgnoreCase);
             var confirmMsg = isShiftPressed
                 ? Lang.Text("Select.Instance.Delete.ConfirmPermanentMessage", mcInstance.Name)
                 : Lang.Text("Select.Instance.Delete.ConfirmMessage", mcInstance.Name);

--- a/Plain Craft Launcher 2/Pages/PageSelectRight.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSelectRight.xaml.cs
@@ -539,15 +539,14 @@ public partial class PageSelectRight
                 : Lang.Text("Select.Instance.Delete.ConfirmMessage", mcInstance.Name);
             var confirmFullMsg = confirmMsg +
                                   (isHintIndie ? "\r\n" + Lang.Text("Select.Instance.Delete.IsolatedWarning") : "");
-            if (isHintIndie && Config.Launch.PreservePersonalFiles)
-                confirmFullMsg += "\r\n" + Lang.Text("Instance.PersonalFiles.Backup.DeleteHint");
+            var backupHint = isHintIndie ? ModPersonalFiles.GetDeleteHint() : null;
+            if (backupHint is not null) confirmFullMsg += "\r\n" + backupHint;
             switch (ModMain.MyMsgBox(confirmFullMsg, Lang.Text("Select.Instance.Delete.ConfirmTitle"),
                         button2: Lang.Text("Common.Action.Cancel"), isWarn: true))
             {
                 case 1:
                 {
-                    if (isHintIndie && Config.Launch.PreservePersonalFiles &&
-                        !ModPersonalFiles.TryBackupBeforeDelete(mcInstance)) return;
+                    if (isHintIndie && !ModPersonalFiles.TryHandleBeforeDelete(mcInstance)) return;
                     ModBase.IniClearCache(Path.Combine(mcInstance.PathIndie, "options.txt"));
                     ((DynamicCacheConfigStorage)ConfigService.GetProvider(ConfigSource.GameInstance)).InvalidateCache(
                         mcInstance.PathInstance);

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml
@@ -161,11 +161,25 @@
                             <local:MyComboBoxItem Content="{DynamicResource Setup.Launch.Options.IpStack.Ipv6}" />
                         </local:MyComboBox>
                     </Grid>
-                    <local:MyCheckBox x:Name="CheckArgumentPreservePersonalFiles" Height="28"
-                                      Margin="0,10,0,0" Tag="LaunchArgumentPreservePersonalFiles"
-                                      Text="{DynamicResource Setup.Launch.Options.PersonalFilesBackup}"
-                                      ToolTip="{DynamicResource Setup.Launch.Options.PersonalFilesBackup.ToolTip}"
-                                      Change="CheckBoxChange" />
+                    <Grid Margin="0,10,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="Name" />
+                            <ColumnDefinition Width="1*" />
+                            <ColumnDefinition Width="60" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock VerticalAlignment="Center" HorizontalAlignment="Left"
+                                   Text="{DynamicResource Setup.Launch.Options.PersonalFilesBackup}"
+                                   Margin="0,0,25,0" />
+                        <local:MyComboBox x:Name="ComboArgumentPersonalFilesBackup" Grid.Column="1"
+                                          Grid.ColumnSpan="2" Tag="LaunchArgumentPersonalFilesBackupMode"
+                                          SelectionChanged="ComboChange"
+                                          ToolTip="{DynamicResource Setup.Launch.Options.PersonalFilesBackup.ToolTip}">
+                            <local:MyComboBoxItem Content="{DynamicResource Common.Action.Close}" />
+                            <local:MyComboBoxItem Content="{DynamicResource Setup.Launch.Options.PersonalFilesBackup.AskEveryTime}"
+                                                  IsSelected="True" />
+                            <local:MyComboBoxItem Content="{DynamicResource Setup.Launch.Options.PersonalFilesBackup.Always}" />
+                        </local:MyComboBox>
+                    </Grid>
                 </StackPanel>
             </local:MyCard>
             <local:MyCard Margin="0,0,0,15" Title="{DynamicResource Setup.Launch.Memory.Title}">

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml
@@ -161,6 +161,11 @@
                             <local:MyComboBoxItem Content="{DynamicResource Setup.Launch.Options.IpStack.Ipv6}" />
                         </local:MyComboBox>
                     </Grid>
+                    <local:MyCheckBox x:Name="CheckArgumentPreservePersonalFiles" Height="28"
+                                      Margin="0,10,0,0" Tag="LaunchArgumentPreservePersonalFiles"
+                                      Text="{DynamicResource Setup.Launch.Options.PersonalFilesBackup}"
+                                      ToolTip="{DynamicResource Setup.Launch.Options.PersonalFilesBackup.ToolTip}"
+                                      Change="CheckBoxChange" />
                 </StackPanel>
             </local:MyCard>
             <local:MyCard Margin="0,0,0,15" Title="{DynamicResource Setup.Launch.Memory.Title}">

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml.cs
@@ -54,6 +54,7 @@ public partial class PageSetupLaunch
             TextArgumentTitle.Text = Config.Launch.Title;
             TextArgumentInfo.Text = Config.Launch.TypeInfo;
             ComboArgumentIndieV2.SelectedIndex = Config.Launch.IndieSolutionV2;
+            CheckArgumentPreservePersonalFiles.Checked = Config.Launch.PreservePersonalFiles;
             ComboArgumentVisibie.SelectedIndex = (int)Config.Launch.LauncherVisibility;
             ComboArgumentPriority.SelectedValue = ((int)Config.Launch.ProcessPriority).ToString();
             ComboArgumentWindowType.SelectedIndex = (int)Config.Launch.GameWindowMode;

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml.cs
@@ -54,7 +54,7 @@ public partial class PageSetupLaunch
             TextArgumentTitle.Text = Config.Launch.Title;
             TextArgumentInfo.Text = Config.Launch.TypeInfo;
             ComboArgumentIndieV2.SelectedIndex = Config.Launch.IndieSolutionV2;
-            CheckArgumentPreservePersonalFiles.Checked = Config.Launch.PreservePersonalFiles;
+            ComboArgumentPersonalFilesBackup.SelectedIndex = (int)Config.Launch.PersonalFilesBackup;
             ComboArgumentVisibie.SelectedIndex = (int)Config.Launch.LauncherVisibility;
             ComboArgumentPriority.SelectedValue = ((int)Config.Launch.ProcessPriority).ToString();
             ComboArgumentWindowType.SelectedIndex = (int)Config.Launch.GameWindowMode;


### PR DESCRIPTION
## 修改内容

- 在全局启动设置增加“每次询问／始终备份／关闭”三种保护模式，默认选择“每次询问”
- “每次询问”仅在隔离实例的 `screenshots` 中存在文件时弹窗，可选择备份并删除、直接删除或取消
- 选择备份时，将 `screenshots` 与 `schematics` 递归复制到所选游戏目录下的 `PCL/PersonalFiles/<实例名>`
- 备份失败时取消删除，避免原文件随实例删除；两个现有实例删除入口均已接入
- “始终备份”模式的删除确认框显示“删除前会备份文件到文件夹。”

## 验证情况

- `dotnet build "Plain Craft Launcher 2/Plain Craft Launcher 2.csproj" -c Debug -p:Platform=x64 --no-restore`：通过，0 个错误
- 按官方工作流参数执行 x64 `CI` 配置 `dotnet publish --no-self-contained`：通过；生成的 .NET 10 可执行文件启动冒烟通过
- 仓库外临时验证程序：截图目录不存在、空目录、嵌套截图触发，以及递归复制、已有文件覆盖、缺失来源目录与时间戳保持均通过
- 当前 Windows 账户无创建符号链接权限；重解析点跳过逻辑已通过代码审查确认
- `git diff --check dev...feat/protect-instance-personal-files`：通过

## AI 使用

- GPT-5.6：辅助实现、代码审查与本地验证
- 仓库内未新增文档或测试文件

## Summary by Sourcery

在删除隔离的 Minecraft 实例时，新增可配置的个人文件保护机制，包括可选地将截图和结构文件备份到专用归档文件夹。

New Features:
- 引入一个全局设置，用于控制在删除隔离实例时个人文件的备份行为，支持三种模式：禁用、每次询问以及始终备份。
- 添加备份流程，将实例的截图和结构文件复制到所选游戏目录下的按实例划分的归档目录中，并在备份成功后向用户展示反馈。

Enhancements:
- 将个人文件备份提示和处理逻辑集成到现有的两个实例删除入口中，如果备份失败则阻止删除操作。
- 通过使用不区分大小写的路径比较和增强的删除确认消息，改进隔离实例的检测和相关提示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable protection for personal files when deleting isolated Minecraft instances, including optional backup of screenshots and schematics to a dedicated archive folder.

New Features:
- Introduce a global setting to control personal files backup behavior when deleting isolated instances, with disabled, ask every time, and always backup modes.
- Add a backup workflow that copies instance screenshots and schematics into a per-instance archive under the selected game directory and shows user feedback on success.

Enhancements:
- Integrate personal files backup hints and handling into both existing instance deletion entry points, preventing deletion if backup fails.
- Improve isolated-instance detection and messaging by using case-insensitive path comparison and augmented delete confirmations.

</details>