### PR TITLE
修复仓库 Star 历史图表链接

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -65,7 +65,7 @@ You can still try using the latest launcher version on unsupported platforms, bu
 ## 🌟 Statistic
 ![Alt](https://repobeats.axiom.co/api/embed/3e46296e6e3a134991a783480fd2f62723bb0353.svg "Repobeats analytics image")
 
-[![Star History Chart](https://api.star-history.com/svg?repos=PCL-Community/PCL-CE&type=Date)](https://www.star-history.com/#PCL-Community/PCL-CE&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=PCL-Community/PCL-CE&type=Date)](https://star-history.dera.page/#PCL-Community/PCL-CE&type=Date)
 
 **Views** (Total / Today): [![Hits](https://hits.zkitefly.eu.org/?tag=https://github.com/PCL-Community/PCL-CE)](https://hits.zkitefly.eu.org/?tag=https://github.com/PCL-Community/PCL-CE&web=true)
 ## ❤️ Contributors

--- a/README-ZH_TW.md
+++ b/README-ZH_TW.md
@@ -65,7 +65,7 @@ PCL CE 始終建議使用最新版本的作業系統以獲得最佳體驗。
 ## 🌟 統計資料
 ![Alt](https://repobeats.axiom.co/api/embed/3e46296e6e3a134991a783480fd2f62723bb0353.svg "Repobeats analytics image")
 
-[![Star History Chart](https://api.star-history.com/svg?repos=PCL-Community/PCL-CE&type=Date)](https://www.star-history.com/#PCL-Community/PCL-CE&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=PCL-Community/PCL-CE&type=Date)](https://star-history.dera.page/#PCL-Community/PCL-CE&type=Date)
 
 **此頁瀏覽量**（總計 / 今日）：[![Hits](https://hits.zkitefly.eu.org/?tag=https://github.com/PCL-Community/PCL-CE)](https://hits.zkitefly.eu.org/?tag=https://github.com/PCL-Community/PCL-CE&web=true)
 ## ❤️ 貢獻者

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ PCL CE 始终建议使用最新版本的操作系统以获得最佳体验。
 ## 🌟 统计数据
 ![Alt](https://repobeats.axiom.co/api/embed/3e46296e6e3a134991a783480fd2f62723bb0353.svg "Repobeats analytics image")
 
-[![Star History Chart](https://api.star-history.com/svg?repos=PCL-Community/PCL-CE&type=Date)](https://www.star-history.com/#PCL-Community/PCL-CE&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=PCL-Community/PCL-CE&type=Date)](https://star-history.dera.page/#PCL-Community/PCL-CE&type=Date)
 
 **此页浏览量**（总计 / 今日）：[![Hits](https://hits.zkitefly.eu.org/?tag=https://github.com/PCL-Community/PCL-CE)](https://hits.zkitefly.eu.org/?tag=https://github.com/PCL-Community/PCL-CE&web=true)
 ## ❤️ 贡献者


### PR DESCRIPTION
当前的 Star 历史图表因 GitHub stargazer API 限制而失效，无法正常展示仓库的 Star 增长情况。本 PR 将其迁移至可用的新地址，使图表恢复显示。

## Summary by Sourcery

文档：
- 更新英文、简体中文和繁体中文 README 中的 star 历史图表链接，以恢复星标统计信息的显示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Refresh star history chart URLs in English, Simplified Chinese, and Traditional Chinese READMEs to restore the star statistics display.

</details>