### PR TITLE
feat(launch):支持自动下载arm64的jdk,lwjgl

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModJava.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModJava.cs
@@ -448,8 +448,14 @@ public static class ModJava
                 targetValue = match.Value;
             }
 
-            if (targetName is null)
+            // Mojang 会将该平台未提供的组件表示为空数组，此时同样回退到下一平台
+            if (targetValue is not JsonArray targetArray || targetArray.Count == 0)
+            {
+                targetName = null;
+                targetValue = null;
                 continue;
+            }
+
             if (platformName != platformNames[0])
                 ModLaunch.McLaunchLog(
                     $"Mojang 未提供 {loader.input} 的 {platformNames[0]} 构建，已回退到 {platformName} 版本");

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModJava.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModJava.cs
@@ -424,25 +424,40 @@ public static class ModJava
                 {
                     "https://bmclapi2.bangbang93.com/v1/products/java-runtime/2ec0cc96c44e5a76b9c8b7c39df7210883d12871/all.json"
                 }), isJson: true);
-        // 查找要下载的目标 Java
+        // 查找要下载的目标 Java（Windows ARM64 设备优先使用 ARM64 构建，缺失时回退 x64，#3486）
         string? targetName = null;
         JsonNode? targetValue = null;
-        var components =
-            (JsonObject)((JsonObject)ModBase.GetJson(indexFileStr))[$"windows-x{(SystemInfo.Is32BitSystem ? "86" : "64")}"];
-        if (components.ContainsKey(loader.input)) // 精确匹配
+        var index = (JsonObject)ModBase.GetJson(indexFileStr);
+        var platformNames = SystemInfo.IsArm64System
+            ? new[] { "windows-arm64", "windows-x64" }
+            : new[] { $"windows-x{(SystemInfo.Is32BitSystem ? "86" : "64")}" };
+        foreach (var platformName in platformNames)
         {
-            targetName = loader.input;
-            targetValue = components[loader.input];
-        }
-        else // 模糊匹配
-        {
-            var match = components.FirstOrDefault(c =>
-                c.Value?.AsArray().FirstOrDefault()?["version"]?["name"]?.ToString().StartsWithF(loader.input) ?? false);
-            targetName = match.Key;
-            targetValue = match.Value;
+            if (index[platformName] is not JsonObject components)
+                continue;
+            if (components.ContainsKey(loader.input)) // 精确匹配
+            {
+                targetName = loader.input;
+                targetValue = components[loader.input];
+            }
+            else // 模糊匹配
+            {
+                var match = components.FirstOrDefault(c =>
+                    c.Value?.AsArray().FirstOrDefault()?["version"]?["name"]?.ToString().StartsWithF(loader.input) ?? false);
+                targetName = match.Key;
+                targetValue = match.Value;
+            }
+
             if (targetName is null)
-                throw new Exception($"未能找到所需的 Java {loader.input}");
+                continue;
+            if (platformName != platformNames[0])
+                ModLaunch.McLaunchLog(
+                    $"Mojang 未提供 {loader.input} 的 {platformNames[0]} 构建，已回退到 {platformName} 版本");
+            break;
         }
+
+        if (targetName is null)
+            throw new Exception($"未能找到所需的 Java {loader.input}");
 
         var targetComponent = targetValue?.AsArray().FirstOrDefault();
         if (targetComponent is null)

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
@@ -2939,8 +2939,9 @@ public static class ModLaunch
                                 @"assets\virtual\legacy")); // 1.5.2 的 pre-1.6 资源索引应与 legacy 合并
         gameArguments.Add("${assets_index_name}", ModAssets.McAssetsGetIndexName(instance));
 
-        // 支持库参数
-        var libList = ModLibrary.McLibListGet(instance, true);
+        // 支持库参数（Natives 架构必须与所选 Java 一致，而非仅跟随操作系统架构，#3486）
+        var libList = ModLibrary.McLibListGet(instance, true,
+            SystemInfo.IsArm64System && mcLaunchJavaSelected?.Installation.Architecture == MachineType.ARM64);
         loader.output = libList;
         var cpStrings = new List<string>();
         string optiFineCp = null;

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLibrary.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLibrary.cs
@@ -144,13 +144,31 @@ public static class ModLibrary
     private static readonly string osVersion = Environment.OSVersion.Version.ToString();
 
     /// <summary>
+    ///     判断该支持库是否应改用官方 ARM64 Natives。
+    ///     LWJGL 自 3.3.0 起在 Maven Central 提供 natives-windows-arm64；更早版本回退使用 x64 Natives（经 Windows 转译运行）。
+    ///     注意 Natives 必须与实际运行游戏的 Java 架构一致，而非仅跟随操作系统架构。
+    /// </summary>
+    private static bool IsArm64NativeLibrary(JsonObject library, bool useArm64Native)
+    {
+        if (!useArm64Native)
+            return false;
+        var name = library["name"]?.ToString();
+        if (name is null || !name.StartsWithF("org.lwjgl:"))
+            return false;
+        var version = name.Split(":").ElementAtOrDefault(2);
+        return version is not null && McVersionComparer.CompareVersionGe(version, "3.3.0");
+    }
+
+    /// <summary>
     ///     递归获取 Minecraft 某一实例的完整支持库列表。
     /// </summary>
-    public static List<McLibToken> McLibListGet(McInstance mcInstance, bool includeInstanceJar)
+    public static List<McLibToken> McLibListGet(McInstance mcInstance, bool includeInstanceJar,
+        bool? useArm64Native = null)
     {
         // 获取当前支持库列表
         ModBase.Log("[Minecraft] 获取支持库列表：" + mcInstance.Name);
-        var result = McLibListGetWithJson(mcInstance.JsonObject, targetMcInstance: mcInstance);
+        var result = McLibListGetWithJson(mcInstance.JsonObject, targetMcInstance: mcInstance,
+            useArm64Native: useArm64Native);
 
         // 需要添加原版 Jar
         if (includeInstanceJar)
@@ -234,9 +252,12 @@ public static class ModLibrary
     ///     获取 Minecraft 某一实例忽视继承的支持库列表，即结果中没有继承项。
     /// </summary>
     public static List<McLibToken> McLibListGetWithJson(JsonObject jsonObject,
-        bool keepSameNameDifferentVersionResult = false, string customMcFolder = null, McInstance targetMcInstance = null)
+        bool keepSameNameDifferentVersionResult = false, string customMcFolder = null, McInstance targetMcInstance = null,
+        bool? useArm64Native = null)
     {
         customMcFolder = customMcFolder ?? ModFolder.mcFolderSelected;
+        // 未明确指定时默认跟随操作系统架构；启动流程中应传入所选 Java 的架构
+        var useArm64 = useArm64Native ?? SystemInfo.IsArm64System;
         var basicArray = new List<McLibToken>();
 
         // 添加基础 Json 项
@@ -316,7 +337,7 @@ public static class ModLibrary
                 }
             }
             else if (library["natives"]["windows"] is not null &&
-                     IsArm64NativeLibrary(library)) // ARM64 设备上的 LWJGL 3.3+：改用官方提供的 ARM64 Natives（#3486）
+                     IsArm64NativeLibrary(library, useArm64)) // LWJGL 3.3+：改用官方提供的 ARM64 Natives（#3486）
             {
                 var name = (string)library["name"];
                 var segments = name.Split(":");
@@ -450,8 +471,9 @@ public static class ModLibrary
             ModBase.Log(ex, "实例缺失主 Jar 文件所必须的信息", ModBase.LogLevel.Developer);
         }
 
-        // Library 文件
-        result.AddRange(McLibNetFilesFromTokens(McLibListGet(mcInstance, false)));
+        // Library 文件（Natives 架构跟随本次启动所选的 Java）
+        result.AddRange(McLibNetFilesFromTokens(McLibListGet(mcInstance, false,
+            SystemInfo.IsArm64System && ModLaunch.mcLaunchJavaSelected?.Installation.Architecture == MachineType.ARM64)));
 
         // Authlib-Injector 文件
         var authlibTargetFile = Path.Combine(ModBase.pathPure, "authlib-injector.jar");

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLibrary.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLibrary.cs
@@ -216,6 +216,21 @@ public static class ModLibrary
     }
 
     /// <summary>
+    ///     判断该支持库在 Windows ARM64 设备上是否应改用官方 ARM64 Natives。
+    ///     LWJGL 自 3.3.0 起在 Maven Central 提供 natives-windows-arm64；更早版本回退使用 x64 Natives（经 Windows 转译运行）。
+    /// </summary>
+    private static bool IsArm64NativeLibrary(JsonObject library)
+    {
+        if (!SystemInfo.IsArm64System)
+            return false;
+        var name = library["name"]?.ToString();
+        if (name is null || !name.StartsWithF("org.lwjgl:"))
+            return false;
+        var version = name.Split(":").ElementAtOrDefault(2);
+        return version is not null && McVersionComparer.CompareVersionGe(version, "3.3.0");
+    }
+
+    /// <summary>
     ///     获取 Minecraft 某一实例忽视继承的支持库列表，即结果中没有继承项。
     /// </summary>
     public static List<McLibToken> McLibListGetWithJson(JsonObject jsonObject,
@@ -299,6 +314,22 @@ public static class ModLibrary
                         IsNatives = false, Sha1 = null
                     });
                 }
+            }
+            else if (library["natives"]["windows"] is not null &&
+                     IsArm64NativeLibrary(library)) // ARM64 设备上的 LWJGL 3.3+：改用官方提供的 ARM64 Natives（#3486）
+            {
+                var name = (string)library["name"];
+                var segments = name.Split(":");
+                var mavenPath = segments[0].Replace(".", "/") + "/" + segments[1] + "/" + segments[2] + "/" +
+                                segments[1] + "-" + segments[2] + "-natives-windows-arm64.jar";
+                basicArray.Add(new McLibToken
+                {
+                    OriginalName = name,
+                    Url = "https://repo1.maven.org/maven2/" + mavenPath,
+                    LocalPath = McLibGet(name, customMcFolder: customMcFolder)
+                        .Replace(".jar", "-natives-windows-arm64.jar"),
+                    size = 0L, IsNatives = true, Sha1 = null, IsLocal = isLocal
+                });
             }
             else if (library["natives"]["windows"] is not null) // 有 Windows Natives
             {


### PR DESCRIPTION
close #3486 
没arm电脑，没测试

## Sourcery 总结

为 Java 运行时和 LWJGL 原生库添加 Windows ARM64 支持，并提供兼容性回退机制。

新功能：
- 在 Windows ARM64 设备上自动下载 ARM64 Java 运行时；当 ARM64 构建不可用时回退到 x64。
- 在 Windows ARM64 设备上，对 3.3.0 及更高版本使用官方 ARM64 LWJGL 原生库，同时对较旧版本保留使用 x64 原生库。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

支持 Windows ARM64 运行时和原生库选择，同时在 ARM64 构建不可用及旧版 LWJGL 的情况下保持兼容性。

新功能：
- 添加 Windows ARM64 Java 运行时选择功能；当 ARM64 构建不可用时，自动回退到 x64。
- 在 Windows ARM64 系统上，对 3.3.0 及更高版本使用官方 ARM64 LWJGL 原生库。

错误修复：
- 确保原生库选择遵循实际选定的 Java 运行时架构，包括 ARM64 系统上的 x64 回退。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support Windows ARM64 runtime and native library selection while preserving compatibility with unavailable ARM64 builds and older LWJGL versions.

New Features:
- Add Windows ARM64 Java runtime selection with automatic fallback to x64 when an ARM64 build is unavailable.
- Use official ARM64 LWJGL natives for version 3.3.0 and newer on Windows ARM64 systems.

Bug Fixes:
- Ensure native library selection follows the architecture of the Java runtime actually selected, including x64 fallback on ARM64 systems.

</details>

</details>