### PR TITLE
fix: Download manager button breaks when one of multiple tasks completes

### DIFF
--- a/Plain Craft Launcher 2/Modules/Base/ModLoader.cs
+++ b/Plain Craft Launcher 2/Modules/Base/ModLoader.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualBasic.CompilerServices;
+using Microsoft.VisualBasic.CompilerServices;
 using PCL.Core.App;
 using PCL.Core.Utils;
 using System.Collections;
@@ -43,8 +43,7 @@ public static class ModLoader
             var newProgress = LoaderTaskbarProgressGet();
             // 若单个任务已中止，或全部任务已完成，则刷新并移除
             foreach (var Task in loaderTaskbar)
-                if (loaderTaskbar.All(l => l.State != ModBase.LoadState.Loading) ||
-                    Task.State == ModBase.LoadState.Waiting || Task.State == ModBase.LoadState.Aborted)
+                if (Task.State != ModBase.LoadState.Loading)
                 {
                     ModMain.frmSpeedLeft?.TaskRefresh(Task);
                     loaderTaskbar.Remove(Task);


### PR DESCRIPTION
Fixes #3567.

### Summary
When multiple download/update tasks are running and one finishes, the original condition \loaderTaskbar.All(l => l.State != ModBase.LoadState.Loading)\ prevented finished tasks from being removed from \loaderTaskbar\.
This caused the taskbar manager UI (\PageSpeedLeft\) to repeatedly re-create and dispose the UI card on every 300ms Watcher tick, resulting in UI glitches and a broken download manager button.

This fix removes tasks from \loaderTaskbar\ as soon as they are no longer \Loading\.

## Sourcery 摘要

错误修复：
- 修复多个下载或更新任务中的某个任务完成时下载管理器按钮和任务栏 UI 的显示问题，及时移除所有非加载中的任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix the download manager button and taskbar UI glitches when one of multiple download or update tasks completes by removing every non-loading task promptly.

</details>