### PR TITLE
fix(launch): match IsGBKEncoding behavior with Framework

### DIFF
--- a/PCL.Core/Utils/OS/KernelInterop.cs
+++ b/PCL.Core/Utils/OS/KernelInterop.cs
@@ -71,6 +71,9 @@ public static partial class KernelInterop
 
     [LibraryImport("kernel32.dll", EntryPoint = "GetConsoleWindow")]
     private static partial nint _GetConsoleWindow();
+    
+    [LibraryImport("kernel32.dll")]
+    internal static partial uint GetACP();
 
     // ReSharper restore InconsistentNaming, UnusedMember.Local
 

--- a/PCL.Core/Utils/OS/SystemInfo.cs
+++ b/PCL.Core/Utils/OS/SystemInfo.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace PCL.Core.Utils.OS;
 
@@ -19,7 +18,7 @@ public static class SystemInfo
     /// <summary>
     /// 是否使用 GBK 编码。
     /// </summary>
-    public static readonly bool IsGBKEncoding = Encoding.Default.CodePage == 936;
+    public static readonly bool IsGBKEncoding = KernelInterop.GetACP() == 936;
 
     /// <summary>
     /// 系统信息描述，例如 Microsoft Windows 11 专业工作站版 10.0.22635.0


### PR DESCRIPTION
问题
---

https://github.com/PCL-Community/PCL-CE/blob/d66cb76faeb438e85b7bd694c9f10f669044491d/Plain%20Craft%20Launcher%202/Modules/Minecraft/ModLaunch.cs#L2099-L2108

在启动过程中，此处使用运行时常量 `IsGBKEncoding` 确定当前 Active CodePage 是否是 GBK，
但在此项目迁移到非 Framework 后，Encoding.Default.CodePage 现在永远为 UTF-8，使 `IsGBKEncoding` 永远为 `false`。

这一问题造成原本可以在 GBK 系统上运行多版本隔离实例的启动过程错误跳过分支，
从而总是使用同一 natives 目录解压 lwjgl 等，并造成启动多个不同依赖版本实例时，后续实例无法启动。

目的
---
此修复使启动过程尊重原始开发人员意图。

权衡
---

此处有两个接近等价的方案，使用：

```csharp
Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
Encoding.GetEncoding(0).CodePage == 936;
```

此方法需要预先修改全局状态，依赖执行顺序，如分离引入 Provider 过程到 `Program.cs` 易被误删或影响行为，故放弃。

目前的从 `kernel32.dll` 获取 ACP 的操作可完全等价于 .NET Framework 中代码的行为，且确保相对原子化的可靠工具常量，故选择。

## Sourcery 摘要

恢复准确的活动代码页检测，以防止 GBK 系统上多个隔离实例启动失败。

错误修复：
- 修正应用程序启动期间对 GBK 系统的检测，使隔离的 Minecraft 实例能够选择适当的原生依赖目录并可靠启动。

增强功能：
- 通过直接确定 Windows 活动代码页，使 `IsGBKEncoding` 的行为与 .NET Framework 保持一致。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

恢复与 Framework 兼容的活动代码页检测，以防止独立的 Minecraft 实例在 GBK 系统上启动失败。

Bug 修复：
- 在应用程序启动期间恢复准确的 GBK 系统检测，使独立的 Minecraft 实例能够选择正确的本机依赖目录并可靠启动。

增强功能：
- 通过直接确定 Windows 活动代码页，使 `IsGBKEncoding` 的行为与 .NET Framework 保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore Framework-compatible active code page detection to prevent isolated Minecraft instances from failing on GBK systems.

Bug Fixes:
- Restore accurate GBK system detection during application startup so isolated Minecraft instances select the correct native dependency directories and can launch reliably.

Enhancements:
- Align IsGBKEncoding behavior with .NET Framework by determining the Windows active code page directly.

</details>

</details>