### PR TITLE
fix(launch): fix mc before 13w25a

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
@@ -1731,7 +1731,8 @@ public static class ModLaunch
 
         // 本地化 Minecraft 启动信息
         var basicString = version.JsonObject["minecraftArguments"].ToString();
-        if (!basicString.Contains("--height"))
+        if (!basicString.Contains("--height") && 
+            version.releaseTime >= new DateTime(2013, 6, 17)) // 2013-06-17 => 13w25a
             basicString += " --height ${resolution_height} --width ${resolution_width}";
         dataList.Add(basicString);
 


### PR DESCRIPTION
This PR fixes #2635.

问题
---

https://github.com/PCL-Community/PCL-CE/blob/d66cb76faeb438e85b7bd694c9f10f669044491d/Plain%20Craft%20Launcher%202/Modules/Minecraft/ModLaunch.cs#L1355-L1361

使用 `minecraftArguments` 判断进入下面旧版参数生成逻辑，符合原 issue 中的 [13w18a 元数据](https://piston-meta.mojang.com/v1/packages/79bef69b5542046e705a57784cc63574748effe2/13w18a.json) 特征。

https://github.com/PCL-Community/PCL-CE/blob/d66cb76faeb438e85b7bd694c9f10f669044491d/Plain%20Craft%20Launcher%202/Modules/Minecraft/ModLaunch.cs#L1728-L1736

此处总是会添加宽高启动参数。
分析 13w18a 入口可以注意到，其并不支持宽高参数，且在指定相关参数时报错。

分析前一个正式版（1.5.2）注意到，其不支持宽高参数，但在指定无关参数时不会报错。
后一个正式版（1.6）支持宽高参数，第一个支持宽高参数的测试版是 13w25a（2013-06-17）。

影响范围
---

初步检查，应当是 13w16a-13w25a（不含）。

## Sourcery 摘要

错误修复：
- 启动 13w25a 之前发布的 Minecraft 版本时，防止添加不受支持的窗口大小参数。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

错误修复：
- 启动 13w25a 之前发布的 Minecraft 版本时，防止添加不受支持的窗口大小参数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent unsupported window-size arguments from being added when launching Minecraft versions released before 13w25a.

</details>

</details>