### PR TITLE
fix(setup-java): 修复 Java 选择页面刷新无效

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupJava.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupJava.xaml.cs
@@ -34,7 +34,11 @@ public partial class PageSetupJava
 
     private void Load_GetJavaList(ModLoader.LoaderTask<bool, List<JavaEntry>> loader)
     {
-        if (loader.input) JavaService.JavaManager.ScanJavaAsync().GetAwaiter().GetResult();
+        if (loader.input || loader.isForceRestarting)
+        {
+            JavaService.JavaManager.ScanJavaAsync(force: true).GetAwaiter().GetResult();
+            JavaService.JavaManager.CheckAllAvailability();
+        }
         loader.output = ModJava.Javas.GetSortedJavaList();
     }
 


### PR DESCRIPTION
close #3562

## Sourcery 总结

修复 Java 设置页面的刷新和选择回退行为。

错误修复：
- 修复 Java 选择刷新问题，确保在强制刷新列表时能够检测到新扫描到的 Java 安装，并重新检查其可用性。
- 当配置的 Java 选择不再匹配任何可用安装时，清除无效的配置选择，并回退到自动选择。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the Java setup page refresh and selection fallback behavior.

Bug Fixes:
- Fix Java selection refresh so newly scanned Java installations are detected and availability is rechecked when the list is forcibly refreshed.
- Clear an invalid configured Java selection and fall back to automatic selection when it no longer matches an available installation.

</details>

<details>
<summary>Original summary in English</summary>



</details>